### PR TITLE
OPRUN-3268: Add pointer to tooling README for downstreaming info

### DIFF
--- a/openshift/dev_notes.md
+++ b/openshift/dev_notes.md
@@ -1,0 +1,4 @@
+## Notes for developers
+
+### Information on the downstreaming process can be found here:
+[https://github.com/openshift/operator-framework-tooling/blob/main/README.md](https://github.com/openshift/operator-framework-tooling/blob/main/README.md)


### PR DESCRIPTION
To make the downstream repos self explanatory we need to link to the information about how the downstreaming process works.