### PR TITLE
OPRUN-3291: UPSTREAM: <carry>: Enable Validating Admission Policy APIs downstream

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -58,12 +58,6 @@ for container_name in "${!IMAGE_MAPPINGS[@]}"; do
   $YQ -i 'select(.kind == "Namespace").metadata.annotations += {"workload.openshift.io/allowed": "management"}' "$TMP_KUSTOMIZE_OUTPUT"
 done
 
-# Exclude ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
-# APIs from downstream build as these API are currently not enabled by default.
-# In the OCP 4.17 (K8s 1.30) they will be become available
-# and we will be able to remove this to enforce admission policies
-$YQ -i 'del(select((.kind|downcase) == "validatingadmissionpolicy" or (.kind|downcase) == "validatingadmissionpolicybinding"))' "$TMP_KUSTOMIZE_OUTPUT"
-
 # Use yq to split the single yaml file into 1 per document.
 # Naming convention: $index-$kind-$namespace-$name. If $namespace is empty, just use the empty string.
 (
@@ -107,3 +101,4 @@ cp "$TMP_MANIFEST_DIR"/* "$MANIFEST_DIR"/
     fi
   done
 )
+

--- a/openshift/manifests/17-validatingadmissionpolicy-openshift-operator-controller-operator-controller-clusterextensions-package-uniqueness.yml
+++ b/openshift/manifests/17-validatingadmissionpolicy-openshift-operator-controller-operator-controller-clusterextensions-package-uniqueness.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: operator-controller-clusterextensions-package-uniqueness
+  namespace: openshift-operator-controller
+spec:
+  failurePolicy: Fail
+  matchConditions:
+    - expression: request.operation == 'CREATE' || oldObject.spec.packageName != object.spec.packageName
+      name: only-create-or-package-change
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - olm.operatorframework.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusterextensions
+  paramKind:
+    apiVersion: olm.operatorframework.io/v1alpha1
+    kind: ClusterExtension
+  validations:
+    - expression: object.spec.packageName != params.spec.packageName
+      messageExpression: '''Package "'' + string(object.spec.packageName) + ''" is already installed via ClusterExtension "'' +  string(params.metadata.name) + ''"'''
+      reason: Invalid

--- a/openshift/manifests/18-validatingadmissionpolicybinding-openshift-operator-controller-operator-controller-clusterextensions-package-uniqueness-binding.yml
+++ b/openshift/manifests/18-validatingadmissionpolicybinding-openshift-operator-controller-operator-controller-clusterextensions-package-uniqueness-binding.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: operator-controller-clusterextensions-package-uniqueness-binding
+  namespace: openshift-operator-controller
+spec:
+  paramRef:
+    parameterNotFoundAction: Allow
+    selector: {}
+  policyName: operator-controller-clusterextensions-package-uniqueness
+  validationActions:
+    - Deny


### PR DESCRIPTION
* This reverts commit 3f079c45a30844eed5d31ff8e768cef8ebddd813.
* Adds new manifests with Validating Admission Policy APIs