### PR TITLE
[release-4.15] OCPBUGS-37549: Set required-scc for openshift workloads

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -54,6 +54,7 @@ for container_name in "${!IMAGE_MAPPINGS[@]}"; do
   placeholder="${IMAGE_MAPPINGS[$container_name]}"
   $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.containers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "restricted-v2"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Namespace").metadata.annotations += {"workload.openshift.io/allowed": "management"}' "$TMP_KUSTOMIZE_OUTPUT"
 done

--- a/openshift/manifests/11-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/manifests/11-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -24,6 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
[OCPBUGS-37549](https://issues.redhat.com/browse/OCPBUGS-37549)
Cherry-pick of #100 

**Description of the change:**
This PR explicitly sets the required SCC to be used to admit pods of the `operator-controller-controller-manager` deployment. The SCC chosen is the one that the pods are already getting admitted with, which means that this brings no change to the SCC used.

**Motivation for the change:**
In some cases, custom SCCs can have higher priority than default SCCs, which means that they will be chosen over the default ones. This can lead to unexpected results; in order to protect openshift workloads from this, we must explicitly pin the required SCC to all our workloads in order to make sure that the expected one will be used.