### PR TITLE
OPRUN-3529: UPSTREAM: <carry>: manifests: add hostPath mount for /etc/containers

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -55,7 +55,7 @@ for container_name in "${!IMAGE_MAPPINGS[@]}"; do
   placeholder="${IMAGE_MAPPINGS[$container_name]}"
   $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.containers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
-  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "restricted-v2"}' "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "privileged"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Namespace").metadata.annotations += {"workload.openshift.io/allowed": "management"}' "$TMP_KUSTOMIZE_OUTPUT"
 done

--- a/openshift/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/kustomization.yaml
@@ -11,6 +11,15 @@ resources:
 
 patches:
   - target:
+      kind: ClusterRole
+      name: manager-role
+    path: patches/manager_role.yaml
+  - target:
       kind: Deployment
       name: controller-manager
     path: patches/manager_deployment_ca.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
+    path: patches/manager_deployment_mount_etc_containers.yaml
+  - path: patches/manager_namespace_privileged.yaml

--- a/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_etc_containers.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-containers", "hostPath":{"path":"/etc/containers", "type": "Directory"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}

--- a/openshift/kustomize/overlays/openshift/patches/manager_namespace_privileged.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_namespace_privileged.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/openshift/kustomize/overlays/openshift/patches/manager_role.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_role.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    resourceNames: [privileged]
+    verbs: [use]

--- a/openshift/manifests/00-namespace-openshift-operator-controller.yml
+++ b/openshift/manifests/00-namespace-openshift-operator-controller.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
   name: openshift-operator-controller
   annotations:

--- a/openshift/manifests/09-clusterrole-operator-controller-manager-role.yml
+++ b/openshift/manifests/09-clusterrole-operator-controller-manager-role.yml
@@ -47,3 +47,11 @@ rules:
     verbs:
       - patch
       - update
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/openshift/manifests/18-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/manifests/18-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -18,7 +18,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: privileged
       labels:
         control-plane: operator-controller-controller-manager
     spec:
@@ -78,6 +78,9 @@ spec:
               name: olmv1-certificate
               readOnly: true
               subPath: olm-ca.crt
+            - mountPath: /etc/containers
+              name: etc-containers
+              readOnly: true
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -115,4 +118,8 @@ spec:
             name: operator-controller-openshift-ca
             optional: false
           name: olmv1-certificate
+        - hostPath:
+            path: /etc/containers
+            type: Directory
+          name: etc-containers
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
In order for operator-controller to support disconnected clusters in OCP, it needs access to the `/etc/containers` directory on the node. This PR adds a hostPath volume mount to give it that access. It also changes the security configuration of the namespace and pod to allow privileged access (which is required for hostPath volume mounts).