### PR TITLE
OPRUN-3557: Add test-e2e target for downstream makefile

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -14,3 +14,7 @@ manifests: $(KUSTOMIZE) $(YQ)
 .PHONY: verify-manifests
 verify-manifests: manifests
 	git diff --exit-code
+
+.PHONY: test-e2e
+test-e2e: ## Run the e2e tests. TODO: stub until tests are working downstream
+	/bin/true 


### PR DESCRIPTION
Target is set to always pass while we work on getting the tests to pass downstream. Adding this target allows us to make e2e test changes without having to make PRs against the `openshift/release` repo each time.