### PR TITLE
OPRUN-3554:  UPSTREAM: <carry>: Add hostPath mount for `/var/lib/kubelet`

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -41,7 +41,7 @@ mkdir -p "${TMP_ROOT}/openshift"
 cp -a "${REPO_ROOT}/openshift/kustomize" "${TMP_ROOT}/openshift/kustomize"
 
 # Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
-find "${TMP_ROOT}" -name "*.yaml" -exec sed -i "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+find "${TMP_ROOT}" -name "*.yaml" -exec sed -i.tmp "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
 
 # Create a temp dir for manifests
 TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"

--- a/openshift/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/kustomization.yaml
@@ -22,4 +22,8 @@ patches:
       kind: Deployment
       name: controller-manager
     path: patches/manager_deployment_mount_etc_containers.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
+    path: patches/manager_deployment_mount_auth_host.yaml
   - path: patches/manager_namespace_privileged.yaml

--- a/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_auth_host.yaml
+++ b/openshift/kustomize/overlays/openshift/patches/manager_deployment_mount_auth_host.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"global-auth-file", "hostPath":{"path":"/var/lib/kubelet/config.json", "type": "File"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"global-auth-file", "readOnly": true, "mountPath":"/etc/operator-controller/auth.json"}

--- a/openshift/manifests/18-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/manifests/18-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -81,6 +81,9 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+            - mountPath: /etc/operator-controller/auth.json
+              name: global-auth-file
+              readOnly: true
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
@@ -122,4 +125,8 @@ spec:
             path: /etc/containers
             type: Directory
           name: etc-containers
+        - hostPath:
+            path: /var/lib/kubelet/config.json
+            type: File
+          name: global-auth-file
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
MCO makes the global pull secrets available in `/var/lib/kubelet`. Operator-controller will look for these secrets in `/etc/operator-controller` folder, ref [operator-controller:1303](https://github.com/operator-framework/operator-controller/pull/1303).

This PR hostPath mounts the `/var/lib/kublet` directory from the host to the `/etc/operator-controller` directory in the container's filesystem.

RFC: [OLMv1 Private registry support](https://docs.google.com/document/d/1BXD6kj5zXHcGiqvJOikU2xs8kV26TPnzEKp6n7TKD4M/edit?usp=sharing)