### PR TITLE
OPRUN-3605: UPSTREAM: <carry>: namespace: use privileged PSA for audit and warn levels

### DIFF
--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
@@ -3,4 +3,9 @@ kind: Namespace
 metadata:
   name: system
   labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
     pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/openshift/manifests/00-namespace-openshift-operator-controller.yml
+++ b/openshift/manifests/00-namespace-openshift-operator-controller.yml
@@ -2,8 +2,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
   name: openshift-operator-controller
   annotations:
     workload.openshift.io/allowed: management


### PR DESCRIPTION
It seems we need to set audit and warn levels to privileged to avoid tripping PSA PodSecurityViolation alerts.