### PR TITLE
[release-4.18] OCPBUGS-45114: combine bundle properties from csv and metadata/properties.yaml

### DIFF
--- a/internal/rukpak/convert/registryv1_test.go
+++ b/internal/rukpak/convert/registryv1_test.go
@@ -1,7 +1,9 @@
 package convert
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -24,7 +26,7 @@ import (
 
 func TestRegistryV1Converter(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RegstryV1 suite")
+	RunSpecs(t, "RegistryV1 suite")
 }
 
 var _ = Describe("RegistryV1 Suite", func() {
@@ -415,6 +417,17 @@ var _ = Describe("RegistryV1 Suite", func() {
 				chrt, err := toChart(registryv1Bundle, installNamespace, watchNamespaces)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(chrt.Metadata.Annotations["olm.properties"]).NotTo(BeNil())
+			})
+		})
+
+		Context("Should read the registry+v1 bundle filesystem correctly", func() {
+			It("should include metadata/properties.yaml and csv.metadata.annotations['olm.properties'] in chart metadata", func() {
+				fsys := os.DirFS("testdata/combine-properties-bundle")
+				chrt, err := RegistryV1ToHelmChart(context.Background(), fsys, "", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(chrt).NotTo(BeNil())
+				Expect(chrt.Metadata).NotTo(BeNil())
+				Expect(chrt.Metadata.Annotations).To(HaveKeyWithValue("olm.properties", `[{"type":"from-csv-annotations-key","value":"from-csv-annotations-value"},{"type":"from-file-key","value":"from-file-value"}]`))
 			})
 		})
 

--- a/internal/rukpak/convert/testdata/combine-properties-bundle/manifests/csv.yaml
+++ b/internal/rukpak/convert/testdata/combine-properties-bundle/manifests/csv.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.operatorframework.io/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: test.v1.0.0
+  annotations:
+    olm.properties: '[{"type":"from-csv-annotations-key", "value":"from-csv-annotations-value"}]'
+spec:
+  installModes:
+    - type: AllNamespaces
+      supported: true

--- a/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/annotations.yaml
+++ b/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/annotations.yaml
@@ -1,0 +1,3 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.package.v1: test

--- a/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/properties.yaml
+++ b/internal/rukpak/convert/testdata/combine-properties-bundle/metadata/properties.yaml
@@ -1,0 +1,3 @@
+properties:
+  - type: "from-file-key"
+    value: "from-file-value"


### PR DESCRIPTION
Manual cherry pick of [this commit](https://github.com/openshift/operator-framework-operator-controller/pull/199/commits/b9294a7b1839ec9dd02dcfc337e3a5fb7be30e78).