### PR TITLE
NO-ISSUE: Add catalogd manifests to start to run those tests

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -16,6 +16,7 @@ verify: ## Run downstream-specific verify
 .PHONY: manifests
 manifests: $(KUSTOMIZE) $(YQ)
 	$(DIR)/operator-controller/generate-manifests.sh
+	$(DIR)/catalogd/generate-manifests.sh
 
 .PHONY: verify-manifests
 verify-manifests: manifests
@@ -35,3 +36,8 @@ test-e2e: ## Run the e2e tests.
 	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_IMAGE)
 	cd $(DIR)/../; \
 	go test $(DOWNSTREAM_E2E_FLAGS) ./test/e2e/...;
+	# Run e2e tests for catalogd
+	# TODO: Add build of the testdata/test-catalog.Dockerfile to openshift/release
+	# See that catalogd e2e tests uses testdata/test-catalog.Dockerfile
+	# More info: https://github.com/openshift/release/blob/master/ci-operator/config/openshift/operator-framework-catalogd/openshift-operator-framework-catalogd-main.yaml#L26-L29
+	#$(MAKE) test-e2e -C $(DIR)/../catalogd/

--- a/openshift/catalogd.Dockerfile
+++ b/openshift/catalogd.Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+WORKDIR /build
+COPY . .
+RUN make go-build-local
+
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+USER 1001
+COPY --from=builder /build/bin/catalogd /catalogd
+COPY openshift/catalogd/manifests /openshift/manifests
+
+LABEL io.k8s.display-name="OpenShift Operator Lifecycle Manager Catalog Controller" \
+      io.k8s.description="This is a component of OpenShift Container Platform that provides operator catalog support."

--- a/openshift/catalogd/dependencies.go
+++ b/openshift/catalogd/dependencies.go
@@ -1,0 +1,6 @@
+//go:build tools
+// +build tools
+
+package catalogd
+
+import _ "github.com/openshift/build-machinery-go"

--- a/openshift/catalogd/generate-manifests.sh
+++ b/openshift/catalogd/generate-manifests.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+##################################################
+# Modify these as needed
+##################################################
+
+# This is the namespace where all namespace-scoped resources live
+NAMESPACE=openshift-catalogd
+
+# This is a mapping of deployment container names to image placeholder values. For example, given a deployment with
+# 2 containers named kube-rbac-proxy and manager, their images will be set to ${KUBE_RBAC_PROXY_IMAGE} and
+# ${CATALOGD_IMAGE}, respectively. The cluster-olm-operator will replace these placeholders will real image values.
+declare -A IMAGE_MAPPINGS
+# shellcheck disable=SC2016
+IMAGE_MAPPINGS[kube-rbac-proxy]='${KUBE_RBAC_PROXY_IMAGE}'
+# shellcheck disable=SC2016
+IMAGE_MAPPINGS[manager]='${CATALOGD_IMAGE}'
+
+# This is a mapping of catalogd flag names to values. For example, given a deployment with a container
+# named "manager" and arguments:
+# args:
+#  - --flagname=one
+# and an entry to the FLAG_MAPPINGS of FLAG_MAPPINGS[flagname]='two', the argument will be updated to:
+# args:
+#  - --flagname=two
+#
+# If the flag doesn't already exist - it will be appended to the list.
+declare -A FLAG_MAPPINGS
+# shellcheck disable=SC2016
+FLAG_MAPPINGS[external-address]="catalogd-service.${NAMESPACE}.svc"
+FLAG_MAPPINGS[global-pull-secret]="openshift-config/pull-secret"
+
+##################################################
+# You shouldn't need to change anything below here
+##################################################
+
+# Know where the repo root is so we can reference things relative to it
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Source bingo so we can use kustomize and yq
+. "${REPO_ROOT}/openshift/.bingo/variables.env"
+
+# We're going to do file manipulation, so let's work in a temp dir
+TMP_ROOT="$(mktemp -p . -d 2>/dev/null || mktemp -d ./tmpdir.XXXXXXX)"
+# Make sure to delete the temp dir when we exit
+trap 'rm -rf $TMP_ROOT' EXIT
+
+# Copy all kustomize files into a temp dir
+cp -a "${REPO_ROOT}/catalogd/config/" "${TMP_ROOT}/config/"
+
+mkdir -p "${TMP_ROOT}/openshift/catalogd/"
+cp -a "${REPO_ROOT}/openshift/catalogd/kustomize" "${TMP_ROOT}/openshift/catalogd/kustomize"
+
+# Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
+find "${TMP_ROOT}" -name "*.yaml" -exec sed -i'.bak' "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+find "${TMP_ROOT}" -name "*.bak" -exec rm {} \;
+
+# Create a temp dir for manifests
+TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"
+mkdir -p "$TMP_MANIFEST_DIR"
+
+# Run kustomize, which emits a single yaml file
+TMP_KUSTOMIZE_OUTPUT="${TMP_MANIFEST_DIR}/temp.yaml"
+$KUSTOMIZE build "${TMP_ROOT}/openshift/catalogd/kustomize/overlays/openshift" -o "$TMP_KUSTOMIZE_OUTPUT"
+
+for container_name in "${!IMAGE_MAPPINGS[@]}"; do
+  placeholder="${IMAGE_MAPPINGS[$container_name]}"
+  $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.containers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "privileged"}' "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i 'select(.kind == "Namespace").metadata.annotations += {"workload.openshift.io/allowed": "management"}' "$TMP_KUSTOMIZE_OUTPUT"
+done
+
+# Loop through any flag updates that need to be made to the manager container
+for flag_name in "${!FLAG_MAPPINGS[@]}"; do
+  flagval="${FLAG_MAPPINGS[$flag_name]}"
+
+  # First, update the flag if it exists
+  $YQ -i "(select(.kind == \"Deployment\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .args[] | select(. | contains(\"--$flag_name=\")) | .) = \"--$flag_name=$flagval\"" "$TMP_KUSTOMIZE_OUTPUT"
+
+  # Then, append the flag if it doesn't exist
+  $YQ -i "(select(.kind == \"Deployment\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .args) |= (select(.[] | contains(\"--$flag_name=\")) | .) // . + [\"--$flag_name=$flagval\"]" "$TMP_KUSTOMIZE_OUTPUT"
+done
+
+# Use yq to split the single yaml file into 1 per document.
+# Naming convention: $index-$kind-$namespace-$name. If $namespace is empty, just use the empty string.
+(
+  cd "$TMP_MANIFEST_DIR"
+
+  # shellcheck disable=SC2016
+  ${YQ} -s '$index +"-"+ (.kind|downcase) +"-"+ (.metadata.namespace // "") +"-"+ .metadata.name' temp.yaml
+)
+
+# Delete the single yaml file
+rm "$TMP_KUSTOMIZE_OUTPUT"
+
+# Delete and recreate the actual manifests directory
+MANIFEST_DIR="${REPO_ROOT}/openshift/catalogd/manifests"
+rm -rf "${MANIFEST_DIR}"
+mkdir -p "${MANIFEST_DIR}"
+
+# Copy everything we just generated and split into the actual manifests directory
+cp "$TMP_MANIFEST_DIR"/* "$MANIFEST_DIR"/
+
+# Update file names to be in the format nn-$kind-$namespace-$name
+(
+  cd "$MANIFEST_DIR"
+
+  for f in *; do
+    # Get the numeric prefix from the filename
+    index=$(echo "$f" | cut -d '-' -f 1)
+    # Keep track of the full file name without the leading number and dash
+    name_without_index=${f#$index-}
+    # Fix the double dash in cluster-scoped names
+    name_without_index=${name_without_index//--/-}
+    # Reformat the name so the leading number is always padded to 2 digits
+    new_name=$(printf "%02d" "$index")-$name_without_index
+    # Some file names (namely CRDs) don't end in .yml - make them
+    if ! [[ "$new_name" =~ yml$ ]]; then
+      new_name="${new_name}".yml
+    fi
+    if [[ "$f" != "$new_name" ]]; then
+      # Rename
+      mv "$f" "${new_name}"
+    fi
+  done
+)

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - openshift-certified-operators.yaml
+  - openshift-community-operators.yaml
+  - openshift-redhat-marketplace.yaml
+  - openshift-redhat-operators.yaml

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-certified-operators.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-certified-operators.yaml
@@ -1,0 +1,11 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-certified-operators
+spec:
+  priority: -200
+  source:
+    type: Image
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/certified-operator-index:v4.18

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-community-operators.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-community-operators.yaml
@@ -1,0 +1,11 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-community-operators
+spec:
+  priority: -400
+  source:
+    type: Image
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/community-operator-index:v4.18

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-marketplace.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-marketplace.yaml
@@ -1,0 +1,11 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-redhat-marketplace
+spec:
+  priority: -300
+  source:
+    type: Image
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.18

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-operators.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-operators.yaml
@@ -1,0 +1,11 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-redhat-operators
+spec:
+  priority: -100
+  source:
+    type: Image
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/redhat-operator-index:v4.18

--- a/openshift/catalogd/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- olmv1-ns
+- openshift-config
+- catalogs

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
@@ -1,0 +1,41 @@
+# Adds namespace to all resources.
+namespace: OPENSHIFT-NAMESPACE
+
+namePrefix: catalogd-
+
+resources:
+- ../../../../../../config/base/crd
+- ../../../../../../config/base/rbac
+- ../../../../../../config/base/manager
+- trusted-ca/catalogd_trusted_ca_configmap.yaml
+
+patches:
+- path: patches/manager_namespace_privileged.yaml
+- target:
+    kind: Service
+    name: service
+  path: patches/manager_service.yaml
+- target:
+    kind: MutatingWebhookConfiguration
+    name: mutating-webhook-configuration
+  path: patches/mutating_webhook_config.yaml
+- target:
+    kind: ClusterRole
+    name: manager-role
+  path: patches/manager_role.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: patches/manager_deployment_certs.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: patches/manager_deployment_mount_etc_containers.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: patches/manager_deployment_log_verbosity.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: patches/manager_deployment_node_selection.yaml

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -1,0 +1,27 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"catalogserver-certs", "secret":{"optional":false,"secretName":"catalogserver-cert"}}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"trusted-ca-bundle", "configMap":{"optional":false,"name":"trusted-ca-bundle"}}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"service-ca", "configMap":{"optional":false,"name":"openshift-service-ca.crt"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"catalogserver-certs", "mountPath":"/var/certs"}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"trusted-ca-bundle", "mountPath":"/var/trusted-cas/ca-bundle.crt", "subPath":"ca-bundle.crt"}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"service-ca", "mountPath":"/var/trusted-cas/service-ca.crt", "subPath":"service-ca.crt"}
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--tls-cert=/var/certs/tls.crt"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--tls-key=/var/certs/tls.key"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--ca-certs-dir=/var/trusted-cas"

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_log_verbosity.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_log_verbosity.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--v=${LOG_VERBOSITY}"

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-containers", "hostPath":{"path":"/etc/containers", "type": "Directory"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_node_selection.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_node_selection.yaml
@@ -1,0 +1,25 @@
+- op: add
+  path: /spec/template/spec/nodeSelector
+  value: { "kubernetes.io/os": "linux", "node-role.kubernetes.io/master": "" }
+- op: add
+  path: /spec/template/spec/tolerations
+  value:
+    [
+      {
+        "effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/master",
+        "operator": "Exists",
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "tolerationSeconds": 120,
+      },
+      {
+        "effect": "NoExecute",
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "tolerationSeconds": 120,
+      },
+    ]

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_role.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_role.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    resourceNames: [privileged]
+    verbs: [use]

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_service.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_service.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /metadata/annotations
+  value:
+    service.beta.openshift.io/serving-cert-secret-name: catalogserver-cert
+- op: replace
+  path: /spec/ports/0/port
+  value: 443
+- op: replace
+  path: /spec/ports/0/name
+  value: https

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/mutating_webhook_config.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/mutating_webhook_config.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /metadata/annotations
+  value:
+    service.beta.openshift.io/inject-cabundle: "true"
+- op: replace
+  path: /webhooks/0/clientConfig/service/namespace
+  value: OPENSHIFT-NAMESPACE

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/trusted-ca/catalogd_trusted_ca_configmap.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/trusted-ca/catalogd_trusted_ca_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca-bundle
+

--- a/openshift/catalogd/kustomize/overlays/openshift/openshift-config/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/openshift-config/kustomization.yaml
@@ -1,0 +1,8 @@
+# Adds namespace to all resources.
+namespace: openshift-config
+
+namePrefix: catalogd-
+
+resources:
+- rbac/catalogd_manager_role.yaml
+- rbac/catalogd_manager_role_binding.yaml

--- a/openshift/catalogd/kustomize/overlays/openshift/openshift-config/rbac/catalogd_manager_role.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/openshift-config/rbac/catalogd_manager_role.yaml
@@ -1,0 +1,17 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: olm
+    app.kubernetes.io/name: catalogd
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/openshift/catalogd/kustomize/overlays/openshift/openshift-config/rbac/catalogd_manager_role_binding.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/openshift-config/rbac/catalogd_manager_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: olm
+    app.kubernetes.io/name: catalogd
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: OPENSHIFT-NAMESPACE

--- a/openshift/catalogd/manifests/00-namespace-openshift-catalogd.yml
+++ b/openshift/catalogd/manifests/00-namespace-openshift-catalogd.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/part-of: olm
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+  name: openshift-catalogd
+  annotations:
+    workload.openshift.io/allowed: management

--- a/openshift/catalogd/manifests/01-customresourcedefinition-clustercatalogs.olm.operatorframework.io.yml
+++ b/openshift/catalogd/manifests/01-customresourcedefinition-clustercatalogs.olm.operatorframework.io.yml
@@ -1,0 +1,397 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: clustercatalogs.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterCatalog
+    listKind: ClusterCatalogList
+    plural: clustercatalogs
+    singular: clustercatalog
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.lastUnpacked
+          name: LastUnpacked
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Serving")].status
+          name: Serving
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ClusterCatalog enables users to make File-Based Catalog (FBC) catalog data available to the cluster.
+            For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                spec is the desired state of the ClusterCatalog.
+                spec is required.
+                The controller will work to ensure that the desired
+                catalog is unpacked and served over the catalog content HTTP server.
+              properties:
+                availabilityMode:
+                  default: Available
+                  description: |-
+                    availabilityMode allows users to define how the ClusterCatalog is made available to clients on the cluster.
+                    availabilityMode is optional.
+
+                    Allowed values are "Available" and "Unavailable" and omitted.
+
+                    When omitted, the default value is "Available".
+
+                    When set to "Available", the catalog contents will be unpacked and served over the catalog content HTTP server.
+                    Setting the availabilityMode to "Available" tells clients that they should consider this ClusterCatalog
+                    and its contents as usable.
+
+                    When set to "Unavailable", the catalog contents will no longer be served over the catalog content HTTP server.
+                    When set to this availabilityMode it should be interpreted the same as the ClusterCatalog not existing.
+                    Setting the availabilityMode to "Unavailable" can be useful in scenarios where a user may not want
+                    to delete the ClusterCatalog all together, but would still like it to be treated as if it doesn't exist.
+                  enum:
+                    - Unavailable
+                    - Available
+                  type: string
+                priority:
+                  default: 0
+                  description: |-
+                    priority allows the user to define a priority for a ClusterCatalog.
+                    priority is optional.
+
+                    A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
+                    A higher number means higher priority.
+
+                    It is up to clients to decide how to handle scenarios where multiple ClusterCatalogs with the same priority meet their requirements.
+                    When deciding how to break the tie in this scenario, it is recommended that clients prompt their users for additional input.
+
+                    When omitted, the default priority is 0 because that is the zero value of integers.
+
+                    Negative numbers can be used to specify a priority lower than the default.
+                    Positive numbers can be used to specify a priority higher than the default.
+
+                    The lowest possible value is -2147483648.
+                    The highest possible value is 2147483647.
+                  format: int32
+                  type: integer
+                source:
+                  description: |-
+                    source allows a user to define the source of a catalog.
+                    A "catalog" contains information on content that can be installed on a cluster.
+                    Providing a catalog source makes the contents of the catalog discoverable and usable by
+                    other on-cluster components.
+                    These on-cluster components may do a variety of things with this information, such as
+                    presenting the content in a GUI dashboard or installing content from the catalog on the cluster.
+                    The catalog source must contain catalog metadata in the File-Based Catalog (FBC) format.
+                    For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs.
+                    source is a required field.
+
+                    Below is a minimal example of a ClusterCatalogSpec that sources a catalog from an image:
+
+                     source:
+                       type: Image
+                       image:
+                         ref: quay.io/operatorhubio/catalog:latest
+                  properties:
+                    image:
+                      description: |-
+                        image is used to configure how catalog contents are sourced from an OCI image.
+                        This field is required when type is Image, and forbidden otherwise.
+                      properties:
+                        pollIntervalMinutes:
+                          description: |-
+                            pollIntervalMinutes allows the user to set the interval, in minutes, at which the image source should be polled for new content.
+                            pollIntervalMinutes is optional.
+                            pollIntervalMinutes can not be specified when ref is a digest-based reference.
+
+                            When omitted, the image will not be polled for new content.
+                          minimum: 1
+                          type: integer
+                        ref:
+                          description: |-
+                            ref allows users to define the reference to a container image containing Catalog contents.
+                            ref is required.
+                            ref can not be more than 1000 characters.
+
+                            A reference can be broken down into 3 parts - the domain, name, and identifier.
+
+                            The domain is typically the registry where an image is located.
+                            It must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                            Hyphenation is allowed, but the domain must start and end with alphanumeric characters.
+                            Specifying a port to use is also allowed by adding the ":" character followed by numeric values.
+                            The port must be the last value in the domain.
+                            Some examples of valid domain values are "registry.mydomain.io", "quay.io", "my-registry.io:8080".
+
+                            The name is typically the repository in the registry where an image is located.
+                            It must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                            Multiple names can be concatenated with the "/" character.
+                            The domain and name are combined using the "/" character.
+                            Some examples of valid name values are "operatorhubio/catalog", "catalog", "my-catalog.prod".
+                            An example of the domain and name parts of a reference being combined is "quay.io/operatorhubio/catalog".
+
+                            The identifier is typically the tag or digest for an image reference and is present at the end of the reference.
+                            It starts with a separator character used to distinguish the end of the name and beginning of the identifier.
+                            For a digest-based reference, the "@" character is the separator.
+                            For a tag-based reference, the ":" character is the separator.
+                            An identifier is required in the reference.
+
+                            Digest-based references must contain an algorithm reference immediately after the "@" separator.
+                            The algorithm reference must be followed by the ":" character and an encoded string.
+                            The algorithm must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                            Some examples of valid algorithm values are "sha256", "sha256+b64u", "multihash+base58".
+                            The encoded string following the algorithm must be hex digits (a-f, A-F, 0-9) and must be a minimum of 32 characters.
+
+                            Tag-based references must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters.
+                            The tag must not be longer than 127 characters.
+
+                            An example of a valid digest-based image reference is "quay.io/operatorhubio/catalog@sha256:200d4ddb2a73594b91358fe6397424e975205bfbe44614f5846033cad64b3f05"
+                            An example of a valid tag-based image reference is "quay.io/operatorhubio/catalog:latest"
+                          maxLength: 1000
+                          type: string
+                          x-kubernetes-validations:
+                            - message: must start with a valid domain. valid domains must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                              rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                            - message: a valid name is required. valid names must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                              rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)') != ""
+                            - message: must end with a digest or a tag
+                              rule: self.find('(@.*:)') != "" || self.find(':.*$') != ""
+                            - message: tag is invalid. the tag must not be more than 127 characters
+                              rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'') != "" ? self.find('':.*$'').substring(1).size() <= 127 : true) : true'
+                            - message: tag is invalid. valid tags must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters
+                              rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'') != "" ? self.find('':.*$'').matches('':[\\w][\\w.-]*$'') : true) : true'
+                            - message: digest algorithm is not valid. valid algorithms must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'') : true'
+                            - message: digest is not valid. the encoded string must be at least 32 characters
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size() >= 32 : true'
+                            - message: digest is not valid. the encoded string must only contain hex characters (A-F, a-f, 0-9)
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'') : true'
+                      required:
+                        - ref
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cannot specify pollIntervalMinutes while using digest-based image
+                          rule: 'self.ref.find(''(@.*:)'') != "" ? !has(self.pollIntervalMinutes) : true'
+                    type:
+                      description: |-
+                        type is a reference to the type of source the catalog is sourced from.
+                        type is required.
+
+                        The only allowed value is "Image".
+
+                        When set to "Image", the ClusterCatalog content will be sourced from an OCI image.
+                        When using an image source, the image field must be set and must be the only field defined for this type.
+                      enum:
+                        - Image
+                      type: string
+                  required:
+                    - type
+                  type: object
+                  x-kubernetes-validations:
+                    - message: image is required when source type is Image, and forbidden otherwise
+                      rule: 'has(self.type) && self.type == ''Image'' ? has(self.image) : !has(self.image)'
+              required:
+                - source
+              type: object
+            status:
+              description: |-
+                status contains information about the state of the ClusterCatalog such as:
+                  - Whether or not the catalog contents are being served via the catalog content HTTP server
+                  - Whether or not the ClusterCatalog is progressing to a new state
+                  - A reference to the source from which the catalog contents were retrieved
+              properties:
+                conditions:
+                  description: |-
+                    conditions is a representation of the current state for this ClusterCatalog.
+
+                    The current condition types are Serving and Progressing.
+
+                    The Serving condition is used to represent whether or not the contents of the catalog is being served via the HTTP(S) web server.
+                    When it has a status of True and a reason of Available, the contents of the catalog are being served.
+                    When it has a status of False and a reason of Unavailable, the contents of the catalog are not being served because the contents are not yet available.
+                    When it has a status of False and a reason of UserSpecifiedUnavailable, the contents of the catalog are not being served because the catalog has been intentionally marked as unavailable.
+
+                    The Progressing condition is used to represent whether or not the ClusterCatalog is progressing or is ready to progress towards a new state.
+                    When it has a status of True and a reason of Retrying, there was an error in the progression of the ClusterCatalog that may be resolved on subsequent reconciliation attempts.
+                    When it has a status of True and a reason of Succeeded, the ClusterCatalog has successfully progressed to a new state and is ready to continue progressing.
+                    When it has a status of False and a reason of Blocked, there was an error in the progression of the ClusterCatalog that requires manual intervention for recovery.
+
+                    In the case that the Serving condition is True with reason Available and Progressing is True with reason Retrying, the previously fetched
+                    catalog contents are still being served via the HTTP(S) web server while we are progressing towards serving a new version of the catalog
+                    contents. This could occur when we've initially fetched the latest contents from the source for this catalog and when polling for changes
+                    to the contents we identify that there are updates to the contents.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                lastUnpacked:
+                  description: |-
+                    lastUnpacked represents the last time the contents of the
+                    catalog were extracted from their source format. As an example,
+                    when using an Image source, the OCI image will be pulled and the
+                    image layers written to a file-system backed cache. We refer to the
+                    act of this extraction from the source format as "unpacking".
+                  format: date-time
+                  type: string
+                resolvedSource:
+                  description: resolvedSource contains information about the resolved source based on the source type.
+                  properties:
+                    image:
+                      description: |-
+                        image is a field containing resolution information for a catalog sourced from an image.
+                        This field must be set when type is Image, and forbidden otherwise.
+                      properties:
+                        ref:
+                          description: |-
+                            ref contains the resolved image digest-based reference.
+                            The digest format is used so users can use other tooling to fetch the exact
+                            OCI manifests that were used to extract the catalog contents.
+                          maxLength: 1000
+                          type: string
+                          x-kubernetes-validations:
+                            - message: must start with a valid domain. valid domains must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                              rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                            - message: a valid name is required. valid names must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                              rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)') != ""
+                            - message: must end with a digest
+                              rule: self.find('(@.*:)') != ""
+                            - message: digest algorithm is not valid. valid algorithms must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'') : true'
+                            - message: digest is not valid. the encoded string must be at least 32 characters
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size() >= 32 : true'
+                            - message: digest is not valid. the encoded string must only contain hex characters (A-F, a-f, 0-9)
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'') : true'
+                      required:
+                        - ref
+                      type: object
+                    type:
+                      description: |-
+                        type is a reference to the type of source the catalog is sourced from.
+                        type is required.
+
+                        The only allowed value is "Image".
+
+                        When set to "Image", information about the resolved image source will be set in the 'image' field.
+                      enum:
+                        - Image
+                      type: string
+                  required:
+                    - image
+                    - type
+                  type: object
+                  x-kubernetes-validations:
+                    - message: image is required when source type is Image, and forbidden otherwise
+                      rule: 'has(self.type) && self.type == ''Image'' ? has(self.image) : !has(self.image)'
+                urls:
+                  description: urls contains the URLs that can be used to access the catalog.
+                  properties:
+                    base:
+                      description: |-
+                        base is a cluster-internal URL that provides endpoints for
+                        accessing the content of the catalog.
+
+                        It is expected that clients append the path for the endpoint they wish
+                        to access.
+
+                        Currently, only a single endpoint is served and is accessible at the path
+                        /api/v1.
+
+                        The endpoints served for the v1 API are:
+                          - /all - this endpoint returns the entirety of the catalog contents in the FBC format
+
+                        As the needs of users and clients of the evolve, new endpoints may be added.
+                      maxLength: 525
+                      type: string
+                      x-kubernetes-validations:
+                        - message: must be a valid URL
+                          rule: isURL(self)
+                        - message: scheme must be either http or https
+                          rule: 'isURL(self) ? (url(self).getScheme() == "http" || url(self).getScheme() == "https") : true'
+                  required:
+                    - base
+                  type: object
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/openshift/catalogd/manifests/02-serviceaccount-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests/02-serviceaccount-openshift-catalogd-catalogd-controller-manager.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-controller-manager
+  namespace: openshift-catalogd

--- a/openshift/catalogd/manifests/03-role-openshift-catalogd-catalogd-leader-election-role.yml
+++ b/openshift/catalogd/manifests/03-role-openshift-catalogd-catalogd-leader-election-role.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-leader-election-role
+  namespace: openshift-catalogd
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/openshift/catalogd/manifests/04-role-openshift-config-catalogd-manager-role.yml
+++ b/openshift/catalogd/manifests/04-role-openshift-config-catalogd-manager-role.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-manager-role
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/catalogd/manifests/05-clusterrole-catalogd-manager-role.yml
+++ b/openshift/catalogd/manifests/05-clusterrole-catalogd-manager-role.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: catalogd-manager-role
+rules:
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clustercatalogs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clustercatalogs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clustercatalogs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/openshift/catalogd/manifests/06-clusterrole-catalogd-metrics-reader.yml
+++ b/openshift/catalogd/manifests/06-clusterrole-catalogd-metrics-reader.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/openshift/catalogd/manifests/07-clusterrole-catalogd-proxy-role.yml
+++ b/openshift/catalogd/manifests/07-clusterrole-catalogd-proxy-role.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-proxy-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/openshift/catalogd/manifests/08-rolebinding-openshift-catalogd-catalogd-leader-election-rolebinding.yml
+++ b/openshift/catalogd/manifests/08-rolebinding-openshift-catalogd-catalogd-leader-election-rolebinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-leader-election-rolebinding
+  namespace: openshift-catalogd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: catalogd-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests/09-rolebinding-openshift-config-catalogd-manager-rolebinding.yml
+++ b/openshift/catalogd/manifests/09-rolebinding-openshift-config-catalogd-manager-rolebinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-manager-rolebinding
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: catalogd-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests/10-clusterrolebinding-catalogd-manager-rolebinding.yml
+++ b/openshift/catalogd/manifests/10-clusterrolebinding-catalogd-manager-rolebinding.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: catalogd-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests/11-clusterrolebinding-catalogd-proxy-rolebinding.yml
+++ b/openshift/catalogd/manifests/11-clusterrolebinding-catalogd-proxy-rolebinding.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: catalogd-proxy-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests/12-configmap-openshift-catalogd-catalogd-trusted-ca-bundle.yml
+++ b/openshift/catalogd/manifests/12-configmap-openshift-catalogd-catalogd-trusted-ca-bundle.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: catalogd-trusted-ca-bundle
+  namespace: openshift-catalogd

--- a/openshift/catalogd/manifests/13-service-openshift-catalogd-catalogd-service.yml
+++ b/openshift/catalogd/manifests/13-service-openshift-catalogd-catalogd-service.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: catalogserver-cert
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-service
+  namespace: openshift-catalogd
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    - name: webhook
+      port: 9443
+      protocol: TCP
+      targetPort: 9443
+    - name: metrics
+      port: 7443
+      protocol: TCP
+      targetPort: 7443
+  selector:
+    control-plane: catalogd-controller-manager

--- a/openshift/catalogd/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -1,0 +1,133 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubectl.kubernetes.io/default-logs-container: manager
+  labels:
+    control-plane: catalogd-controller-manager
+  name: catalogd-controller-manager
+  namespace: openshift-catalogd
+spec:
+  minReadySeconds: 5
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+      labels:
+        control-plane: catalogd-controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - ppc64le
+                      - s390x
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - args:
+            - --leader-elect
+            - --metrics-bind-address=:7443
+            - --external-address=catalogd-service.openshift-catalogd.svc
+            - --tls-cert=/var/certs/tls.crt
+            - --tls-key=/var/certs/tls.key
+            - --ca-certs-dir=/var/trusted-cas
+            - --v=${LOG_VERBOSITY}
+            - --global-pull-secret=openshift-config/pull-secret
+          command:
+            - ./catalogd
+          image: ${CATALOGD_IMAGE}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /var/cache/
+              name: cache
+            - mountPath: /var/certs
+              name: catalogserver-certs
+            - mountPath: /var/trusted-cas/ca-bundle.crt
+              name: trusted-ca-bundle
+              subPath: ca-bundle.crt
+            - mountPath: /var/trusted-cas/service-ca.crt
+              name: service-ca
+              subPath: service-ca.crt
+            - mountPath: /etc/containers
+              name: etc-containers
+              readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: catalogd-controller-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120
+      volumes:
+        - emptyDir: {}
+          name: cache
+        - name: catalogserver-certs
+          secret:
+            optional: false
+            secretName: catalogserver-cert
+        - configMap:
+            name: catalogd-trusted-ca-bundle
+            optional: false
+          name: trusted-ca-bundle
+        - configMap:
+            name: openshift-service-ca.crt
+            optional: false
+          name: service-ca
+        - hostPath:
+            path: /etc/containers
+            type: Directory
+          name: etc-containers
+      priorityClassName: system-cluster-critical

--- a/openshift/catalogd/manifests/15-clustercatalog-openshift-certified-operators.yml
+++ b/openshift/catalogd/manifests/15-clustercatalog-openshift-certified-operators.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-certified-operators
+spec:
+  priority: -200
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/certified-operator-index:v4.18
+    type: Image

--- a/openshift/catalogd/manifests/16-clustercatalog-openshift-community-operators.yml
+++ b/openshift/catalogd/manifests/16-clustercatalog-openshift-community-operators.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-community-operators
+spec:
+  priority: -400
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/community-operator-index:v4.18
+    type: Image

--- a/openshift/catalogd/manifests/17-clustercatalog-openshift-redhat-marketplace.yml
+++ b/openshift/catalogd/manifests/17-clustercatalog-openshift-redhat-marketplace.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-redhat-marketplace
+spec:
+  priority: -300
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.18
+    type: Image

--- a/openshift/catalogd/manifests/18-clustercatalog-openshift-redhat-operators.yml
+++ b/openshift/catalogd/manifests/18-clustercatalog-openshift-redhat-operators.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-redhat-operators
+spec:
+  priority: -100
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    type: Image

--- a/openshift/catalogd/manifests/19-mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
+++ b/openshift/catalogd/manifests/19-mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: catalogd-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: catalogd-service
+        namespace: openshift-catalogd
+        path: /mutate-olm-operatorframework-io-v1-clustercatalog
+        port: 9443
+    failurePolicy: Fail
+    matchConditions:
+      - expression: '''name'' in object.metadata && (!has(object.metadata.labels) || !(''olm.operatorframework.io/metadata.name'' in object.metadata.labels) || object.metadata.labels[''olm.operatorframework.io/metadata.name''] != object.metadata.name)'
+        name: MissingOrIncorrectMetadataNameLabel
+    name: inject-metadata-name.olm.operatorframework.io
+    rules:
+      - apiGroups:
+          - olm.operatorframework.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clustercatalogs
+    sideEffects: None
+    timeoutSeconds: 10


### PR DESCRIPTION
- Move to openshift/catalogd the specific manifest under: https://github.com/openshift/operator-framework-catalogd/tree/main/openshift 
- Add call to generate catalogd manifest to 'make manifest'. Make verify test is now done for catalogd and operator-controller Openshift's manifests