### PR TITLE
OCPBUGS-48795: Add /etc/docker to the operator-controller and catalogd deployments

### DIFF
--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
@@ -4,3 +4,9 @@
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-docker", "hostPath":{"path":"/etc/docker", "type": "Directory"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"etc-docker", "readOnly": true, "mountPath":"/etc/docker"}

--- a/openshift/catalogd/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests/14-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -90,6 +90,9 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+            - mountPath: /etc/docker
+              name: etc-docker
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
@@ -133,4 +136,8 @@ spec:
             path: /etc/containers
             type: Directory
           name: etc-containers
+        - hostPath:
+            path: /etc/docker
+            type: Directory
+          name: etc-docker
       priorityClassName: system-cluster-critical

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
@@ -4,3 +4,9 @@
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-docker", "hostPath":{"path":"/etc/docker", "type": "Directory"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"etc-docker", "readOnly": true, "mountPath":"/etc/docker"}

--- a/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -89,6 +89,9 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+            - mountPath: /etc/docker
+              name: etc-docker
+              readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
@@ -132,4 +135,8 @@ spec:
             path: /etc/containers
             type: Directory
           name: etc-containers
+        - hostPath:
+            path: /etc/docker
+            type: Directory
+          name: etc-docker
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
This allows for use of the any image.config.openshift.io trusted CAs