### PR TITLE
OCPBUGS-49299: [release-4.18] UPSTREAM: <carry>: resolve issue with pre-mature mounting of trusted CA configmap

### DIFF
--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -1,6 +1,6 @@
 - op: add
   path: /spec/template/spec/volumes/-
-  value: {"name":"trusted-ca-bundle", "configMap":{"optional":false,"name":"trusted-ca-bundle"}}
+  value: {"name":"trusted-ca-bundle", "configMap":{"optional":false,"name":"trusted-ca-bundle", "items":[{"key":"ca-bundle.crt","path":"ca-bundle.crt"}]}}
 - op: add
   path: /spec/template/spec/volumes/-
   value: {"name":"service-ca", "configMap":{"optional":false,"name":"openshift-service-ca.crt"}}

--- a/openshift/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -132,6 +132,9 @@ spec:
         - emptyDir: {}
           name: cache
         - configMap:
+            items:
+              - key: ca-bundle.crt
+                path: ca-bundle.crt
             name: operator-controller-trusted-ca-bundle
             optional: false
           name: trusted-ca-bundle


### PR DESCRIPTION
Manual cherry-pick of #237 