### PR TITLE
[release-4.18] OCPBUGS-49315: Add /etc/docker to the operator-controller deployment

### DIFF
--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
@@ -4,3 +4,9 @@
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}
+- op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-docker", "hostPath":{"path":"/etc/docker", "type": "Directory"}}
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"etc-docker", "readOnly": true, "mountPath":"/etc/docker"}

--- a/openshift/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -85,6 +85,9 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+            - mountPath: /etc/docker
+              name: etc-docker
+              readOnly: true
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --http2-disable
@@ -143,4 +146,8 @@ spec:
             path: /etc/containers
             type: Directory
           name: etc-containers
+        - hostPath:
+            path: /etc/docker
+            type: Directory
+          name: etc-docker
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
This allows for use of the any image.config.openshift.io trusted CAs

Signed-off-by: Todd Short <todd.short@me.com>
(cherry picked from commit 45ec92bac8a782812035471776b1415393be52db)