### PR TITLE
WIP: Remove use of subPath

### DIFF
--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
@@ -23,6 +23,10 @@ patches:
   - target:
       kind: Deployment
       name: controller-manager
+    path: patches/manager_deployment_poststart.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
     path: patches/manager_deployment_mount_etc_containers.yaml
   - target:
       kind: Deployment

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -12,10 +12,10 @@
   value: {"name":"operator-controller-certs", "mountPath":"/var/certs"}
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
-  value: {"name":"trusted-ca-bundle", "mountPath":"/var/trusted-cas/ca-bundle.crt", "subPath":"ca-bundle.crt" }
+  value: {"name":"trusted-ca-bundle", "mountPath":"/var/trusted-cas/trusted-ca-bundle" }
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
-  value: {"name":"service-ca", "mountPath":"/var/trusted-cas/service-ca.crt", "subPath":"service-ca.crt" }
+  value: {"name":"service-ca", "mountPath":"/var/trusted-cas/service-ca" }
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: "--tls-cert=/var/certs/tls.crt"

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_poststart.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_poststart.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /spec/template/spec/containers/0/lifecycle
+  value: {}
+- op: add
+  path: /spec/template/spec/containers/0/lifecycle/postStart
+  value: {}
+- op: add
+  path: /spec/template/spec/containers/0/lifecycle/postStart/exec
+  value:
+    command: ["/bin/sh", "-c", "cd /var/trusted-cas && find */ -maxdepth 1 -mindepth 1 -type f -name '*.crt' -exec ln -s {} . \\;"]

--- a/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -52,6 +52,13 @@ spec:
             - /operator-controller
           image: ${OPERATOR_CONTROLLER_IMAGE}
           imagePullPolicy: IfNotPresent
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - cd /var/trusted-cas && find */ -maxdepth 1 -mindepth 1 -type f -name '*.crt' -exec ln -s {} . \;
           livenessProbe:
             httpGet:
               path: /healthz
@@ -80,12 +87,10 @@ spec:
               name: cache
             - mountPath: /var/certs
               name: operator-controller-certs
-            - mountPath: /var/trusted-cas/ca-bundle.crt
+            - mountPath: /var/trusted-cas/trusted-ca-bundle
               name: trusted-ca-bundle
-              subPath: ca-bundle.crt
-            - mountPath: /var/trusted-cas/service-ca.crt
+            - mountPath: /var/trusted-cas/service-ca
               name: service-ca
-              subPath: service-ca.crt
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true


### PR DESCRIPTION
This removes the use of subPath, which has limitations.

CAs are still put into the /var/trusted-cas directory, but as a subdir. Then a postStart lifecycle event is used to create symlinks