### PR TITLE
WIP: Change certificate usage

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -294,8 +294,8 @@ func main() {
 		BaseCachePath: filepath.Join(cachePath, "unpack"),
 		SourceContextFunc: func(logger logr.Logger) (*types.SystemContext, error) {
 			srcContext := &types.SystemContext{
-				DockerCertPath: caCertDir,
-				OCICertPath:    caCertDir,
+				DockerCertPath: "", // use default path, not caCertDir
+				OCICertPath:    "", // use default path, not caCertDir
 			}
 			if _, err := os.Stat(authFilePath); err == nil && globalPullSecretKey != nil {
 				logger.Info("using available authentication information for pulling image")

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -3,19 +3,13 @@
   value: {"name":"operator-controller-certs", "secret":{"optional":false,"secretName":"operator-controller-cert"}}
 - op: add
   path: /spec/template/spec/volumes/-
-  value: {"name":"trusted-ca-bundle", "configMap":{"optional":false,"name":"trusted-ca-bundle", "items":[{"key":"ca-bundle.crt","path":"ca-bundle.crt"}]}}
-- op: add
-  path: /spec/template/spec/volumes/-
-  value: {"name":"service-ca", "configMap":{"optional":false,"name":"openshift-service-ca.crt"}}
+  value: {"name":"service-ca", "configMap":{"optional":false,"name":"openshift-service-ca.crt", "items":[{"key":"service-ca.crt", "path":"service-ca.crt"}]}}
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value: {"name":"operator-controller-certs", "mountPath":"/var/certs"}
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
-  value: {"name":"trusted-ca-bundle", "mountPath":"/var/trusted-cas/ca-bundle.crt", "subPath":"ca-bundle.crt" }
-- op: add
-  path: /spec/template/spec/containers/0/volumeMounts/-
-  value: {"name":"service-ca", "mountPath":"/var/trusted-cas/service-ca.crt", "subPath":"service-ca.crt" }
+  value: {"name":"service-ca", "mountPath":"/var/trusted-cas/"}
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: "--tls-cert=/var/certs/tls.crt"

--- a/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -80,12 +80,8 @@ spec:
               name: cache
             - mountPath: /var/certs
               name: operator-controller-certs
-            - mountPath: /var/trusted-cas/ca-bundle.crt
-              name: trusted-ca-bundle
-              subPath: ca-bundle.crt
-            - mountPath: /var/trusted-cas/service-ca.crt
+            - mountPath: /var/trusted-cas/
               name: service-ca
-              subPath: service-ca.crt
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
@@ -122,12 +118,8 @@ spec:
             secretName: operator-controller-cert
         - configMap:
             items:
-              - key: ca-bundle.crt
-                path: ca-bundle.crt
-            name: operator-controller-trusted-ca-bundle
-            optional: false
-          name: trusted-ca-bundle
-        - configMap:
+              - key: service-ca.crt
+                path: service-ca.crt
             name: openshift-service-ca.crt
             optional: false
           name: service-ca


### PR DESCRIPTION
--ca-cert-dir is now for the service CA to talk to catalogd We are now telling containers/image to use the default path, which includes /etc/docker, rather than /var/trusted-cas (i.e. --ca-cert-dir)