### PR TITLE
 NO-ISSUE: Cleanup openshift/Makefile by removing no longer required comments regards catalogd e2e tests

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -37,8 +37,3 @@ test-e2e: ## Run the e2e tests.
 	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_IMAGE)
 	cd $(DIR)/../; \
 	go test $(DOWNSTREAM_E2E_FLAGS) ./test/e2e/...;
-	# Run e2e tests for catalogd
-	# TODO: Add build of the testdata/test-catalog.Dockerfile to openshift/release
-	# See that catalogd e2e tests uses testdata/test-catalog.Dockerfile
-	# More info: https://github.com/openshift/release/blob/master/ci-operator/config/openshift/operator-framework-catalogd/openshift-operator-framework-catalogd-main.yaml#L26-L29
-	#$(MAKE) test-e2e -C $(DIR)/../catalogd/


### PR DESCRIPTION
Just call the same e2e tests in the same target that is defined in https://github.com/tmshort/openshift-release/blob/df9b9696af771cd0dc93ae17a290a92c4ef04d7d/ci-operator/config/openshift/operator-framework-operator-controller/openshift-operator-framework-operator-controller-main.yaml#L116C11-L123 to ensure that we are keeping the same previous behaviour of the legacy catalogd downstream repository. 