### PR TITLE
WIP: Add logging to certpoolwatcher and client

### DIFF
--- a/catalogd/cmd/catalogd/main.go
+++ b/catalogd/cmd/catalogd/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -119,6 +120,7 @@ func main() {
 	flag.StringVar(&globalPullSecret, "global-pull-secret", "", "The <namespace>/<name> of the global pull secret that is going to be used to pull bundle images.")
 
 	klog.InitFlags(flag.CommandLine)
+	logrus.SetLevel(logrus.DebugLevel)
 
 	// Combine both flagsets and parse them
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/catalogd/internal/controllers/core/clustercatalog_controller.go
+++ b/catalogd/internal/controllers/core/clustercatalog_controller.go
@@ -40,6 +40,7 @@ import (
 	catalogdv1 "github.com/operator-framework/operator-controller/catalogd/api/v1"
 	"github.com/operator-framework/operator-controller/catalogd/internal/source"
 	"github.com/operator-framework/operator-controller/catalogd/internal/storage"
+	"github.com/operator-framework/operator-controller/internal/httputil"
 )
 
 const (
@@ -229,6 +230,10 @@ func (r *ClusterCatalogReconciler) reconcile(ctx context.Context, catalog *catal
 
 	unpackResult, err := r.Unpacker.Unpack(ctx, catalog)
 	if err != nil {
+		l := ctrl.Log.WithName("catalog-unpacker")
+		if httputil.LogUnverifiedCertificate(err, l) {
+			httputil.DumpCertificates("/etc/docker/certs.d", l)
+		}
 		unpackErr := fmt.Errorf("source catalog content: %w", err)
 		updateStatusProgressing(&catalog.Status, catalog.GetGeneration(), unpackErr)
 		return ctrl.Result{}, unpackErr

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
@@ -120,6 +121,7 @@ func main() {
 	flag.StringVar(&globalPullSecret, "global-pull-secret", "", "The <namespace>/<name> of the global pull secret that is going to be used to pull bundle images.")
 
 	klog.InitFlags(flag.CommandLine)
+	logrus.SetLevel(logrus.DebugLevel)
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	features.OperatorControllerFeatureGate.AddFlag(pflag.CommandLine)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/operator-framework/helm-operator-plugins v0.7.0
 	github.com/operator-framework/operator-registry v1.48.0
 	github.com/prometheus/client_golang v1.20.5
+	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
@@ -192,7 +193,6 @@ require (
 	github.com/sigstore/fulcio v1.4.5 // indirect
 	github.com/sigstore/rekor v1.3.6 // indirect
 	github.com/sigstore/sigstore v1.8.4 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect

--- a/internal/catalogmetadata/client/client.go
+++ b/internal/catalogmetadata/client/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/declcfg"
 
 	catalogd "github.com/operator-framework/operator-controller/catalogd/api/v1"
+	"github.com/operator-framework/operator-controller/internal/httputil"
 )
 
 const (
@@ -147,7 +148,7 @@ func (c *Client) doRequest(ctx context.Context, catalog *catalogd.ClusterCatalog
 
 	resp, err := client.Do(req)
 	if err != nil {
-		logX509Error(err, ctrl.Log.WithName("catalog-client"))
+		_ = httputil.LogUnverifiedCertificate(err, ctrl.Log.WithName("catalog-client"))
 		return nil, fmt.Errorf("error performing request: %v", err)
 	}
 

--- a/internal/controllers/clusterextension_controller.go
+++ b/internal/controllers/clusterextension_controller.go
@@ -53,6 +53,7 @@ import (
 	"github.com/operator-framework/operator-controller/internal/bundleutil"
 	"github.com/operator-framework/operator-controller/internal/conditionsets"
 	"github.com/operator-framework/operator-controller/internal/contentmanager"
+	"github.com/operator-framework/operator-controller/internal/httputil"
 	"github.com/operator-framework/operator-controller/internal/labels"
 	"github.com/operator-framework/operator-controller/internal/resolve"
 	rukpaksource "github.com/operator-framework/operator-controller/internal/rukpak/source"
@@ -257,6 +258,10 @@ func (r *ClusterExtensionReconciler) reconcile(ctx context.Context, ext *ocv1.Cl
 		// Wrap the error passed to this with the resolution information until we have successfully
 		// installed since we intend for the progressing condition to replace the resolved condition
 		// and will be removing the .status.resolution field from the ClusterExtension status API
+		l := ctrl.Log.WithName("operator-controller-unpacker")
+		if httputil.LogUnverifiedCertificate(err, l) {
+			httputil.DumpCertificates("/etc/docker/certs.d", l)
+		}
 		setStatusProgressing(ext, wrapErrorWithResolutionInfo(resolvedBundleMetadata, err))
 		setInstalledStatusFromBundle(ext, installedBundle)
 		return ctrl.Result{}, err

--- a/internal/httputil/certlog.go
+++ b/internal/httputil/certlog.go
@@ -1,14 +1,76 @@
 package httputil
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
 )
+
+const (
+	defaultLogLevel = 0 // 4
+)
+
+func DumpCertificates(path string, log logr.Logger) {
+	var paths []string
+	if path == "" {
+		paths = []string{"/etc/docker/certs.d", "/etc/containers/certs.d"}
+	} else {
+		paths = []string{path}
+	}
+	for _, path := range paths {
+		fi, err := os.Stat(path)
+		if err != nil {
+			log.Error(err, "statting directory", "directory", path)
+			continue
+		}
+		if !fi.IsDir() {
+			log.V(defaultLogLevel).V(1).Info("not a directory", "directory", path)
+			continue
+		}
+		dirEntries, err := os.ReadDir(path)
+		if err != nil {
+			log.Error(err, "reading directory", "directory", path)
+			continue
+		}
+		count := 0
+		for _, e := range dirEntries {
+			hostPath := filepath.Join(path, e.Name())
+			fi, err := os.Stat(hostPath)
+			count++
+			if err != nil {
+				log.Error(err, "dumping certs", "path", hostPath)
+				continue
+			}
+			if !fi.IsDir() {
+				log.V(defaultLogLevel).V(1).Info("ignoring non-directory", "path", hostPath)
+				continue
+			}
+			logPath(hostPath, "dump docker certs", log)
+		}
+	}
+}
+
+func LogUnverifiedCertificate(err error, log logr.Logger) bool {
+	for err != nil {
+		var cvErr *tls.CertificateVerificationError
+		if errors.As(err, &cvErr) {
+			n := 1
+			for _, cert := range cvErr.UnverifiedCertificates {
+				log.Error(err, "unverified cert", "n", n, "subject", cert.Subject, "issuer", cert.Issuer, "DNSNames", cert.DNSNames, "serial", cert.SerialNumber)
+				n = n + 1
+			}
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
 
 func logPath(path, action string, log logr.Logger) {
 	fi, err := os.Stat(path)
@@ -34,7 +96,7 @@ func logPath(path, action string, log logr.Logger) {
 			continue
 		}
 		if fi.IsDir() {
-			log.Info("ignoring subdirectory", "directory", file)
+			log.V(defaultLogLevel).V(1).Info("ignoring subdirectory", "directory", file)
 			continue
 		}
 		logFile(e.Name(), path, action, log)
@@ -43,9 +105,14 @@ func logPath(path, action string, log logr.Logger) {
 
 func logFile(filename, path, action string, log logr.Logger) {
 	filepath := filepath.Join(path, filename)
+	_, err := os.Stat(filepath)
+	if err != nil {
+		log.Error(err, "statting file", "file", filepath)
+		return
+	}
 	data, err := os.ReadFile(filepath)
 	if err != nil {
-		log.Error(err, "error in os.ReadFile()", "file", filename)
+		log.Error(err, "error in os.ReadFile()", "file", filepath)
 		return
 	}
 	logPem(data, filename, path, action, log)
@@ -78,6 +145,6 @@ func logPem(data []byte, filename, path, action string, log logr.Logger) {
 		} else if s := crt.SerialNumber.String(); s != "" {
 			args = append(args, "serial", s)
 		}
-		log.Info(action, args...)
+		log.V(defaultLogLevel).Info(action, args...)
 	}
 }

--- a/internal/httputil/certpoolwatcher.go
+++ b/internal/httputil/certpoolwatcher.go
@@ -52,7 +52,7 @@ func NewCertPoolWatcher(caDir string, log logr.Logger) (*CertPoolWatcher, error)
 	// location, thus they may change, thus we should watch those locations.
 	sslCertDir := os.Getenv("SSL_CERT_DIR")
 	sslCertFile := os.Getenv("SSL_CERT_FILE")
-	log.Info("SSL environment", "SSL_CERT_DIR", sslCertDir, "SSL_CERT_FILE", sslCertFile)
+	log.V(defaultLogLevel).Info("SSL environment", "SSL_CERT_DIR", sslCertDir, "SSL_CERT_FILE", sslCertFile)
 
 	watchPaths := strings.Split(sslCertDir, ":")
 	watchPaths = append(watchPaths, caDir, sslCertFile)

--- a/internal/httputil/certutil.go
+++ b/internal/httputil/certutil.go
@@ -32,10 +32,10 @@ func NewCertPool(caDir string, log logr.Logger) (*x509.CertPool, error) {
 			return nil, err
 		}
 		if fi.IsDir() {
-			log.Info("skip directory", "name", e.Name())
+			log.V(defaultLogLevel).V(1).Info("skip directory", "name", e.Name())
 			continue
 		}
-		log.Info("load certificate", "name", e.Name())
+		log.V(defaultLogLevel).V(1).Info("load certificate", "name", e.Name())
 		data, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("error reading cert file %q: %w", file, err)


### PR DESCRIPTION
Logging now indicates what certificate (by file and X.509 name) is being watched

When an unverified certificate error is returned to the client, log the cert