### PR TITLE
OCPBUGS-48795: overwrites the CA directory only when pullCasDir is not empty

### DIFF
--- a/catalogd/cmd/catalogd/main.go
+++ b/catalogd/cmd/catalogd/main.go
@@ -284,9 +284,11 @@ func main() {
 	imagePuller := &imageutil.ContainersImagePuller{
 		SourceCtxFunc: func(ctx context.Context) (*types.SystemContext, error) {
 			logger := log.FromContext(ctx)
-			srcContext := &types.SystemContext{
-				DockerCertPath: "",
-				OCICertPath:    "",
+			srcContext := &types.SystemContext{}
+			logger.Info("pullCasDir", "value", pullCasDir)
+			if pullCasDir != "" {
+				srcContext.DockerCertPath = pullCasDir
+				srcContext.OCICertPath = pullCasDir
 			}
 			if _, err := os.Stat(authFilePath); err == nil && globalPullSecretKey != nil {
 				logger.Info("using available authentication information for pulling image")

--- a/catalogd/cmd/catalogd/main.go
+++ b/catalogd/cmd/catalogd/main.go
@@ -285,8 +285,8 @@ func main() {
 		SourceCtxFunc: func(ctx context.Context) (*types.SystemContext, error) {
 			logger := log.FromContext(ctx)
 			srcContext := &types.SystemContext{
-				DockerCertPath: pullCasDir,
-				OCICertPath:    pullCasDir,
+				DockerCertPath: "",
+				OCICertPath:    "",
 			}
 			if _, err := os.Stat(authFilePath); err == nil && globalPullSecretKey != nil {
 				logger.Info("using available authentication information for pulling image")


### PR DESCRIPTION
If `pullCasDir` is `""`, then `DockerCertPath` and `OCICertPath` are explicitly set to `""`, which causes `containers/image` not to read `/etc/docker/certs.d/`.
```console
srcContext := &types.SystemContext{
    DockerCertPath: pullCasDir,  // pullCasDir = ""
    OCICertPath:    pullCasDir,
}
```
So, overwrites the CA directory only when pullCasDir is not empty. 