### PR TITLE
NO-ISSUE: Remove vet from openshift verify

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -9,7 +9,7 @@ include $(DIR)/.bingo/Variables.mk
 
 .PHONY: verify
 verify: ## Run downstream-specific verify
-	$(MAKE) tidy fmt vet generate -C $(DIR)/../
+	$(MAKE) tidy fmt generate -C $(DIR)/../
 	$(MAKE) manifests
 	git diff --exit-code
 


### PR DESCRIPTION
The `vet` target was removed upstream.