### PR TITLE
[release-4.18] OCPBUGS-52246: Enable Upstream E2E for 4.18

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -21,6 +21,18 @@ manifests: $(KUSTOMIZE) $(YQ)
 verify-manifests: manifests
 	git diff --exit-code
 
+E2E_REGISTRY_NAME=docker-registry
+E2E_REGISTRY_NAMESPACE=operator-controller-e2e
+export LOCAL_REGISTRY_HOST := $(E2E_REGISTRY_NAME).$(E2E_REGISTRY_NAMESPACE).svc:5000
+export CLUSTER_REGISTRY_HOST := $(E2E_REGISTRY_NAME).$(E2E_REGISTRY_NAMESPACE).svc:5000
+export REG_PKG_NAME := registry-operator
+export E2E_TEST_CATALOG_V1 := e2e/test-catalog:v1
+export E2E_TEST_CATALOG_V2 := e2e/test-catalog:v2
+export CATALOG_IMG := $(LOCAL_REGISTRY_HOST)/$(E2E_TEST_CATALOG_V1)
+# Order matters here, the ".../registries.conf" entry must be last.
+export DOWNSTREAM_E2E_FLAGS := -count=1 -v -skip 'TestClusterExtensionInstallReResolvesWhenNewCatalog|TestClusterExtensionInstallRegistryDynamic|TestClusterExtensionInstallRegistry/package_requires_mirror_registry_configuration_in_/etc/containers/registries.conf'
 .PHONY: test-e2e
-test-e2e: ## Run the e2e tests. TODO: stub until tests are working downstream
-	/bin/true 
+test-e2e: ## Run the e2e tests.
+	$(DIR)/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_IMAGE)
+	cd $(DIR)/../; \
+	go test $(DOWNSTREAM_E2E_FLAGS) ./test/e2e/...;

--- a/openshift/build-test-registry.sh
+++ b/openshift/build-test-registry.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+help="
+build-test-registry.sh is a script to stand up an image registry within a cluster.
+Usage:
+  build-test-registry.sh [NAMESPACE] [NAME] [IMAGE]
+
+Argument Descriptions:
+  - NAMESPACE is the namespace that should be created and is the namespace in which the image registry will be created
+  - NAME is the name that should be used for the image registry Deployment and Service
+  - IMAGE is the name of the image that should be used to run the image registry
+"
+
+if [[ "$#" -ne 3 ]]; then
+  echo "Illegal number of arguments passed"
+  echo "${help}"
+  exit 1
+fi
+
+namespace=$1
+name=$2
+image=$3
+
+oc apply -f - << EOF
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+  labels:
+    app: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+      - name: registry
+        image: ${image}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /registry
+        args:
+        - "--registry-address=:5000"
+        volumeMounts:
+        - mountPath: /var/certs
+          name: operator-controller-e2e-certs
+        env:
+        - name: REGISTRY_HTTP_TLS_CERTIFICATE
+          value: "/var/certs/tls.crt"
+        - name: REGISTRY_HTTP_TLS_KEY
+          value: "/var/certs/tls.key"
+      volumes:
+        - name: operator-controller-e2e-certs
+          secret:
+            optional: false
+            secretName: operator-controller-e2e-certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: operator-controller-e2e-certs
+spec:
+  selector:
+    app: registry
+  ports:
+  - name: http
+    port: 5000
+    targetPort: 5000
+  type: NodePort
+EOF
+
+oc wait --for=condition=Available -n "${namespace}" "deploy/${name}" --timeout=60s
+
+oc apply -f - << EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${name}-push
+  namespace: ${namespace}
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: push
+        image: ${image}
+        command:
+        - /push
+        args: 
+        - "--registry-address=${name}.${namespace}.svc:5000"
+        - "--images-path=/images"
+        volumeMounts:
+        - mountPath: /var/certs
+          name: operator-controller-e2e-certs
+        env:
+        - name: SSL_CERT_DIR
+          value: "/var/certs/"
+      volumes:
+        - name: operator-controller-e2e-certs
+          secret:
+            optional: false
+            secretName: operator-controller-e2e-certs
+EOF
+
+oc wait --for=condition=Complete -n "${namespace}" "job/${name}-push" --timeout=60s

--- a/openshift/registry.Dockerfile
+++ b/openshift/registry.Dockerfile
@@ -11,6 +11,7 @@ USER 1001
 COPY --from=builder /build/registry /registry
 COPY --from=builder /build/push /push
 COPY openshift/manifests /openshift/manifests
+COPY testdata/images /images
 
 LABEL io.k8s.display-name="OpenShift Operator Lifecycle Manager Operator Controller E2E Registry" \
   io.k8s.description="This is a registry image that is used during E2E testing of Operator Controller"


### PR DESCRIPTION
Enables upstream e2e for the release-4.18 branch.