### PR TITLE
OCPBUGS-52161: imageutil: unset PAXRecords and Xattrs in image layers when applying to disk

### DIFF
--- a/internal/shared/util/image/filters.go
+++ b/internal/shared/util/image/filters.go
@@ -23,6 +23,8 @@ func forceOwnershipRWX() archive.Filter {
 		h.Uid = uid
 		h.Gid = gid
 		h.Mode |= 0700
+		h.PAXRecords = nil
+		h.Xattrs = nil //nolint:staticcheck
 		return true, nil
 	}
 }

--- a/internal/shared/util/image/filters_test.go
+++ b/internal/shared/util/image/filters_test.go
@@ -2,10 +2,38 @@ package image
 
 import (
 	"archive/tar"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
+
+func TestForceOwnershipRWX(t *testing.T) {
+	h := tar.Header{
+		Name: "foo/bar",
+		Mode: 0000,
+		Uid:  rand.Int(),
+		Gid:  rand.Int(),
+		Xattrs: map[string]string{ //nolint:staticcheck
+			"foo": "bar",
+		},
+		PAXRecords: map[string]string{
+			"fizz": "buzz",
+		},
+	}
+	ok, err := forceOwnershipRWX()(&h)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Equal(t, "foo/bar", h.Name)
+	assert.Equal(t, int64(0700), h.Mode)
+	assert.Equal(t, os.Getuid(), h.Uid)
+	assert.Equal(t, os.Getgid(), h.Gid)
+	assert.Nil(t, h.PAXRecords)
+	assert.Nil(t, h.Xattrs) //nolint:staticcheck
+}
 
 func TestOnlyPath(t *testing.T) {
 	type testCase struct {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-52161

TL;DR: a cert-manager-operator bundle image contains files that we fail to write to disk because they include xattr "security.capability" that our controller's user apparently cannot write.

This is fixable by simply unsetting xattrs and PAXRecords from the tar header so that we don't actually try to set those attributes on the file we create on disk.

This is not reproducible upstream, even with the exact same bundle image (`registry.redhat.io/cert-manager/cert-manager-operator-bundle@sha256:9a212e5a65ec7a71b4462539902515cfeecf5b02fd8a3f3beaaa6c5ecfc49ec2`)

Upstream PR: https://github.com/operator-framework/operator-controller/pull/1823