### PR TITLE
[release-4.18] OCPBUGS-52173: unset PAXRecords and Xattrs in image layers when applying to disk

### DIFF
--- a/internal/rukpak/source/containers_image.go
+++ b/internal/rukpak/source/containers_image.go
@@ -295,6 +295,8 @@ func applyLayerFilter() archive.Filter {
 		h.Uid = os.Getuid()
 		h.Gid = os.Getgid()
 		h.Mode |= 0700
+		h.PAXRecords = nil
+		h.Xattrs = nil //nolint:staticcheck
 		return true, nil
 	}
 }

--- a/internal/rukpak/source/containers_image_internal_test.go
+++ b/internal/rukpak/source/containers_image_internal_test.go
@@ -1,0 +1,36 @@
+package source
+
+import (
+	"archive/tar"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestApplyLayerFilter(t *testing.T) {
+	h := tar.Header{
+		Name: "foo/bar",
+		Mode: 0000,
+		Uid:  rand.Int(),
+		Gid:  rand.Int(),
+		Xattrs: map[string]string{ //nolint:staticcheck
+			"foo": "bar",
+		},
+		PAXRecords: map[string]string{
+			"fizz": "buzz",
+		},
+	}
+	ok, err := applyLayerFilter()(&h)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	assert.Equal(t, "foo/bar", h.Name)
+	assert.Equal(t, int64(0700), h.Mode)
+	assert.Equal(t, os.Getuid(), h.Uid)
+	assert.Equal(t, os.Getgid(), h.Gid)
+	assert.Nil(t, h.PAXRecords)
+	assert.Nil(t, h.Xattrs) //nolint:staticcheck
+}


### PR DESCRIPTION
Manual cherry pick of https://github.com/openshift/operator-framework-operator-controller/pull/280