### PR TITLE
OCPBUGS-52230: PSA Labels version which should pin the version instead of use latest

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -17,6 +17,19 @@ verify: ## Run downstream-specific verify
 manifests: $(KUSTOMIZE) $(YQ)
 	$(DIR)/operator-controller/generate-manifests.sh
 	$(DIR)/catalogd/generate-manifests.sh
+	make update-k8s-values
+
+# Minor Kubernetes version to build against derived from the client-go dependency version
+KUBE_MINOR ?= $(shell cd $(DIR)/.. && GOFLAGS=-mod=mod go list -m k8s.io/client-go | cut -d" " -f2 | sed -E 's/^v0\.([0-9]+)\.[0-9]+.*$$/1.\1/')
+
+.PHONY: update-k8s-values # HELP Update PSA labels in config manifests with Kubernetes version
+UPDATE_FILES := $(DIR)/catalogd/kustomize $(DIR)/catalogd/manifests \
+               $(DIR)/operator-controller/kustomize $(DIR)/operator-controller/manifests
+update-k8s-values:
+	# Update PSA labels with the correct Kubernetes version
+	find $(UPDATE_FILES) -type f -name '*.yaml' \
+		-exec sed -i.bak -E 's/(pod-security.kubernetes.io\/[a-zA-Z-]+-version:).*/\1 "v$(KUBE_MINOR)"/' {} +
+	find $(UPDATE_FILES) -type f -name '*.yaml.bak' -delete
 
 .PHONY: verify-manifests
 verify-manifests: manifests

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
@@ -5,8 +5,8 @@ metadata:
   name: system
   labels:
     pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/audit-version: "v1.32"
     pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/warn-version: "v1.32"
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: "v1.32"

--- a/openshift/catalogd/manifests/00-namespace-openshift-catalogd.yml
+++ b/openshift/catalogd/manifests/00-namespace-openshift-catalogd.yml
@@ -5,11 +5,11 @@ metadata:
     app.kubernetes.io/part-of: olm
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/audit-version: v1.32
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: v1.32
     pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/warn-version: v1.32
   name: openshift-catalogd
   annotations:
     workload.openshift.io/allowed: management

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
@@ -5,8 +5,8 @@ metadata:
   name: system
   labels:
     pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/audit-version: "v1.32"
     pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/warn-version: "v1.32"
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: "v1.32"

--- a/openshift/operator-controller/manifests/00-namespace-openshift-operator-controller.yml
+++ b/openshift/operator-controller/manifests/00-namespace-openshift-operator-controller.yml
@@ -5,11 +5,11 @@ metadata:
     app.kubernetes.io/part-of: olm
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/audit-version: v1.32
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: v1.32
     pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/warn-version: v1.32
   name: openshift-operator-controller
   annotations:
     workload.openshift.io/allowed: management


### PR DESCRIPTION
OLMv1 should avoid setting Pod Security Admission (PSA) labels to latest. Instead, it should pin the PSA version to match the Kubernetes API version specified in the go.mod file.​

Upstream change: https://github.com/operator-framework/operator-controller/pull/1828