### PR TITLE
OCPBUGS-52234: [release-4.18] UPDATE PSA labels for OCP manifests with k8s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,20 @@ export IMAGE_TAG
 
 IMG := $(IMAGE_REPO):$(IMAGE_TAG)
 
+# Extract Kubernetes client-go version used to set the version to the PSA labels, for ENVTEST and KIND
+ifeq ($(origin K8S_VERSION), undefined)
+K8S_VERSION := $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed -E 's/^v0\.([0-9]+)\.[0-9]+$$/1.\1/')
+endif
+
+# Ensure ENVTEST_VERSION follows correct "X.Y.x" format
+ENVTEST_VERSION := $(K8S_VERSION).x
+
+# Not guaranteed to have patch releases available and node image tags are full versions (i.e v1.28.0 - no v1.28, v1.29, etc.)
+# The K8S_VERSION is set by getting the version of the k8s.io/client-go dependency from the go.mod
+# and sets major version to "1" and the patch version to "0". For example, a client-go version of v0.28.5
+# will map to a K8S_VERSION of 1.28.0
+KIND_CLUSTER_IMAGE := kindest/node:v$(K8S_VERSION).0
+
 # Define dependency versions (use go.mod if we also use Go code from dependency)
 export CERT_MGR_VERSION := v1.15.3
 export CATALOGD_VERSION := $(shell go list -mod=mod -m -f "{{.Version}}" github.com/operator-framework/catalogd)
@@ -44,12 +58,6 @@ ifeq ($(origin KIND_CLUSTER_NAME), undefined)
 KIND_CLUSTER_NAME := operator-controller
 endif
 
-# Not guaranteed to have patch releases available and node image tags are full versions (i.e v1.28.0 - no v1.28, v1.29, etc.)
-# The KIND_NODE_VERSION is set by getting the version of the k8s.io/client-go dependency from the go.mod
-# and sets major version to "1" and the patch version to "0". For example, a client-go version of v0.28.5
-# will map to a KIND_NODE_VERSION of 1.28.0
-KIND_NODE_VERSION := $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1.0/')
-KIND_CLUSTER_IMAGE := kindest/node:v$(KIND_NODE_VERSION)
 
 ifneq (, $(shell command -v docker 2>/dev/null))
 CONTAINER_RUNTIME := docker
@@ -108,8 +116,14 @@ generate: $(CONTROLLER_GEN) #EXHELP Generate code containing DeepCopy, DeepCopyI
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: verify
-verify: tidy fmt vet generate manifests crd-ref-docs #HELP Verify all generated code is up-to-date.
+verify: tidy fmt vet generate manifests crd-ref-docs update-k8s-values #HELP Verify all generated code is up-to-date.
 	git diff --exit-code
+
+.PHONY: update-k8s-values # HELP Update PSA labels in config manifests with Kubernetes version
+update-k8s-values:
+	find config/ -type f -name '*.yaml' -exec \
+	sed -i.bak -E 's/(pod-security.kubernetes.io\/[a-zA-Z-]+-version:).*/\1 "v$(K8S_VERSION)"/g' {} +;
+	find config -type f -name '*.yaml.bak' -delete
 
 .PHONY: fix-lint
 fix-lint: $(GOLANGCI_LINT) #EXHELP Fix lint issues
@@ -152,7 +166,6 @@ test-ext-dev-e2e: $(OPERATOR_SDK) $(KUSTOMIZE) $(KIND) #HELP Run extension creat
 	go test -count=1 -v ./test/extension-developer-e2e/...
 
 .PHONY: test-unit
-ENVTEST_VERSION := $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1.x/')
 UNIT_TEST_DIRS := $(shell go list ./... | grep -v /test/)
 COVERAGE_UNIT_DIR := $(ROOT_DIR)/coverage/unit
 test-unit: $(SETUP_ENVTEST) #HELP Run the unit tests

--- a/config/base/common/namespace.yaml
+++ b/config/base/common/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/part-of: olm
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: "v1.31"
+  name: system

--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: "v1.31"
   name: system
 ---
 apiVersion: apps/v1

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -16,6 +16,18 @@ verify: ## Run downstream-specific verify
 .PHONY: manifests
 manifests: $(KUSTOMIZE) $(YQ)
 	$(DIR)/generate-manifests.sh
+	$(MAKE) update-k8s-values
+
+# Minor Kubernetes version to build against derived from the client-go dependency version
+KUBE_MINOR ?= $(shell cd $(DIR)/.. && GOFLAGS=-mod=mod go list -m k8s.io/client-go | cut -d" " -f2 | sed -E 's/^v0\.([0-9]+)\.[0-9]+.*$$/1.\1/')
+
+.PHONY: update-k8s-values # HELP Update PSA labels in config manifests with Kubernetes version
+UPDATE_FILES := $(DIR)/kustomize $(DIR)/manifests
+update-k8s-values:
+	# Update PSA labels with the correct Kubernetes version
+	find $(UPDATE_FILES) -type f -name '*.yaml' \
+		-exec sed -i.bak -E 's/(pod-security.kubernetes.io\/[a-zA-Z-]+-version:).*/\1 "v$(KUBE_MINOR)"/' {} +
+	find $(UPDATE_FILES) -type f -name '*.yaml.bak' -delete
 
 .PHONY: verify-manifests
 verify-manifests: manifests

--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -54,7 +54,8 @@ mkdir -p "${TMP_ROOT}/openshift"
 cp -a "${REPO_ROOT}/openshift/kustomize" "${TMP_ROOT}/openshift/kustomize"
 
 # Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
-find "${TMP_ROOT}" -name "*.yaml" -exec sed -i "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+find "${TMP_ROOT}" -name "*.yaml" -exec sed -i'.bak' "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+find "${TMP_ROOT}" -name "*.bak" -exec rm {} \;
 
 # Create a temp dir for manifests
 TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_privileged.yaml
@@ -4,8 +4,8 @@ metadata:
   name: system
   labels:
     pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/audit-version: "v1.31"
     pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/warn-version: "v1.31"
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: "v1.31"

--- a/openshift/manifests/00-namespace-openshift-operator-controller.yml
+++ b/openshift/manifests/00-namespace-openshift-operator-controller.yml
@@ -3,11 +3,11 @@ kind: Namespace
 metadata:
   labels:
     pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/audit-version: v1.32
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/enforce-version: v1.32
     pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/warn-version: v1.32
   name: openshift-operator-controller
   annotations:
     workload.openshift.io/allowed: management

--- a/openshift/manifests/00-namespace-openshift-operator-controller.yml
+++ b/openshift/manifests/00-namespace-openshift-operator-controller.yml
@@ -3,11 +3,11 @@ kind: Namespace
 metadata:
   labels:
     pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/audit-version: v1.32
+    pod-security.kubernetes.io/audit-version: v1.31
     pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: v1.32
+    pod-security.kubernetes.io/enforce-version: v1.31
     pod-security.kubernetes.io/warn: privileged
-    pod-security.kubernetes.io/warn-version: v1.32
+    pod-security.kubernetes.io/warn-version: v1.31
   name: openshift-operator-controller
   annotations:
     workload.openshift.io/allowed: management


### PR DESCRIPTION
This change is the same as: https://github.com/openshift/operator-framework-operator-controller/pull/283 but adapted for the old structure. See that I need to solve here the generate script as well to be able to test it out on mac os