### PR TITLE
OCPBUGS-52282: Make /etc/docker optional

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -19,6 +19,8 @@ declare -A IMAGE_MAPPINGS
 IMAGE_MAPPINGS[kube-rbac-proxy]='${KUBE_RBAC_PROXY_IMAGE}'
 # shellcheck disable=SC2016
 IMAGE_MAPPINGS[manager]='${OPERATOR_CONTROLLER_IMAGE}'
+# shellcheck disable=SC2016
+IMAGE_MAPPINGS[init-etc-docker]='${OPERATOR_CONTROLLER_IMAGE}'
 
 # This is a mapping of catalogd flag names to values. For example, given a deployment with a container
 # named "manager" and arguments:
@@ -67,6 +69,7 @@ $KUSTOMIZE build "${TMP_ROOT}/openshift/kustomize/overlays/openshift" -o "$TMP_K
 for container_name in "${!IMAGE_MAPPINGS[@]}"; do
   placeholder="${IMAGE_MAPPINGS[$container_name]}"
   $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.containers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
+  $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.initContainers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "privileged"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
@@ -29,3 +29,7 @@ patches:
       name: controller-manager
     path: patches/manager_deployment_node_selection.yaml
   - path: patches/manager_namespace_privileged.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
+    path: patches/manager_deployment_init_container.yaml

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_init_container.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_init_container.yaml
@@ -1,0 +1,20 @@
+$patch: merge
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: init-etc-docker
+        image: {}
+        imagePullPolicy: IfNotPresent
+        command:
+          - '/bin/bash'
+        args:
+          - '-c'
+          - 'ln -s /hostetc/docker/certs.d /etc/docker/certs.d'
+        volumeMounts:
+        - mountPath: /etc/docker
+          name: etc-docker

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_mount_etc_containers.yaml
@@ -2,11 +2,17 @@
   path: /spec/template/spec/volumes/-
   value: {"name":"etc-containers", "hostPath":{"path":"/etc/containers", "type": "Directory"}}
 - op: add
+  path: /spec/template/spec/volumes/-
+  value: {"name":"etc-host", "hostPath":{"path":"/etc", "type": "Directory"}}
+- op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value: {"name":"etc-containers", "readOnly": true, "mountPath":"/etc/containers"}
 - op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value: {"name":"etc-host", "readOnly": true, "mountPath":"/hostetc"}
+- op: add
   path: /spec/template/spec/volumes/-
-  value: {"name":"etc-docker", "hostPath":{"path":"/etc/docker", "type": "Directory"}}
+  value: {"name":"etc-docker", "emptyDir":{}}
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
-  value: {"name":"etc-docker", "readOnly": true, "mountPath":"/etc/docker"}
+  value: {"name":"etc-docker", "mountPath":"/etc/docker"}

--- a/openshift/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -84,9 +84,11 @@ spec:
             - mountPath: /etc/containers
               name: etc-containers
               readOnly: true
+            - mountPath: /hostetc
+              name: etc-host
+              readOnly: true
             - mountPath: /etc/docker
               name: etc-docker
-              readOnly: true
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --http2-disable
@@ -109,6 +111,18 @@ spec:
               drop:
                 - ALL
           terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+        - args:
+            - -c
+            - ln -s /hostetc/docker/certs.d /etc/docker/certs.d
+          command:
+            - /bin/bash
+          image: ${OPERATOR_CONTROLLER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          name: init-etc-docker
+          volumeMounts:
+            - mountPath: /etc/docker
+              name: etc-docker
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""
@@ -153,7 +167,9 @@ spec:
             type: Directory
           name: etc-containers
         - hostPath:
-            path: /etc/docker
+            path: /etc
             type: Directory
+          name: etc-host
+        - emptyDir: {}
           name: etc-docker
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
Mount /etc/docker indirectly via symlink

This is a 4.18-specific fix to deal with /etc/docker not existing on the node. This can occur when the ImageRegistry capability is not enabled. MCO will be updated to create /etc/docker on the node in 4.17 and later. This will fix 4.17.old (no MCO fix) -> 4.18.new.