### PR TITLE
OCPBUGS-54877: Add catalogd-cas-dir option to op-con

### DIFF
--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -17,5 +17,8 @@
   path: /spec/template/spec/containers/0/args/-
   value: "--tls-key=/var/certs/tls.key"
 - op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--catalogd-cas-dir=/var/ca-certs"
+- op: add
   path: /spec/template/spec/containers/0/env
   value: [{"name":"SSL_CERT_DIR", "value":"/var/ca-certs"}]

--- a/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -45,6 +45,7 @@ spec:
             - --leader-elect
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
+            - --catalogd-cas-dir=/var/ca-certs
             - --v=${LOG_VERBOSITY}
             - --global-pull-secret=openshift-config/pull-secret
           command:


### PR DESCRIPTION
This forces us to _explicitly_ watch the `/var/ca-certs` dir, and properly reload the certs when the `x509.SystemCertPool()` may not.