### PR TITLE
OCPBUGS-48478: [release-4.18] - Add openshift node selector annotation (operator-controller ONLY)

### DIFF
--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -71,7 +71,6 @@ for container_name in "${!IMAGE_MAPPINGS[@]}"; do
   $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "privileged"}' "$TMP_KUSTOMIZE_OUTPUT"
   $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"
-  $YQ -i 'select(.kind == "Namespace").metadata.annotations += {"workload.openshift.io/allowed": "management"}' "$TMP_KUSTOMIZE_OUTPUT"
 done
 
 # Loop through any flag updates that need to be made to the manager container

--- a/openshift/generate-manifests.sh
+++ b/openshift/generate-manifests.sh
@@ -54,7 +54,8 @@ mkdir -p "${TMP_ROOT}/openshift"
 cp -a "${REPO_ROOT}/openshift/kustomize" "${TMP_ROOT}/openshift/kustomize"
 
 # Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
-find "${TMP_ROOT}" -name "*.yaml" -exec sed -i "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+find "${TMP_ROOT}" -name "*.yaml" -exec sed -i'.bak' "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+find "${TMP_ROOT}" -name "*.bak" -exec rm {} \;
 
 # Create a temp dir for manifests
 TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
@@ -29,3 +29,5 @@ patches:
       name: controller-manager
     path: patches/manager_deployment_node_selection.yaml
   - path: patches/manager_namespace_privileged.yaml
+  - path: patches/manager_namespace_annotations.yaml
+

--- a/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_annotations.yaml
+++ b/openshift/kustomize/overlays/openshift/olmv1-ns/patches/manager_namespace_annotations.yaml
@@ -1,0 +1,8 @@
+$patch: merge
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system
+  annotations:
+    workload.openshift.io/allowed: "management"
+    openshift.io/node-selector: ""

--- a/openshift/manifests/00-namespace-openshift-operator-controller.yml
+++ b/openshift/manifests/00-namespace-openshift-operator-controller.yml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: management
   labels:
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/audit-version: latest
@@ -9,5 +12,3 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
     pod-security.kubernetes.io/warn-version: latest
   name: openshift-operator-controller
-  annotations:
-    workload.openshift.io/allowed: management


### PR DESCRIPTION
We are applying the changes from [PR #307](https://github.com/openshift/operator-framework-operator-controller/pull/307) to the operator-controller for the upcoming 4.18 release.

To enable the execution of make manifests under the openshift directory, I had to cherry-pick the fix introduced in [commit 79a11eaae689672e380bcd0c038a9a616d6cc110](https://github.com/openshift/operator-framework-operator-controller/commit/79a11eaae689672e380bcd0c038a9a616d6cc110), which updates the script accordingly.

Furthermore, due to the ongoing monorepo initiative, the changes required for catalogd must be applied manually in the corresponding repository: [openshift/operator-framework-catalogd](https://github.com/openshift/operator-framework-catalogd). See: https://github.com/openshift/operator-framework-catalogd/pull/137