### PR TITLE
OCPBUGS-52615: Bump jinja2 from 3.1.2 to 3.1.6 [Release-4.15]

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ colorama==0.4.6
 cssselect==1.2.0
 ghp-import==2.1.0
 idna==3.4
-Jinja2==3.1.2
+Jinja2==3.1.6
 lxml==4.9.3
 Markdown==3.4.4
 markdown2==2.4.10


### PR DESCRIPTION
Bump the jinja2 from 3.1.2 to 3.1.6

Backport #328 