### PR TITLE
OCPBUGS-52612: Bump jinja2 from 3.1.4 to 3.1.6 [Release-4.16]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ colorama==0.4.6
 cssselect==1.2.0
 ghp-import==2.1.0
 idna==3.7
-Jinja2==3.1.4
+Jinja2==3.1.6
 lxml==5.2.2
 Markdown==3.6
 markdown2==2.4.13


### PR DESCRIPTION
Bump the jinja2 from 3.1.4 to 3.1.6

Backport #319 