### PR TITLE
OCPBUGS-56047: revert "Bump catalog versions to 4.19 [main]"

### DIFF
--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-certified-operators.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-certified-operators.yaml
@@ -8,4 +8,4 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/certified-operator-index:v4.19
+      ref: registry.redhat.io/redhat/certified-operator-index:v4.18

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-community-operators.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-community-operators.yaml
@@ -8,4 +8,4 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/community-operator-index:v4.19
+      ref: registry.redhat.io/redhat/community-operator-index:v4.18

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-marketplace.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-marketplace.yaml
@@ -8,4 +8,4 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.19
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.18

--- a/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-operators.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/catalogs/openshift-redhat-operators.yaml
@@ -8,4 +8,4 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-operator-index:v4.19
+      ref: registry.redhat.io/redhat/redhat-operator-index:v4.18

--- a/openshift/catalogd/manifests/19-clustercatalog-openshift-certified-operators.yml
+++ b/openshift/catalogd/manifests/19-clustercatalog-openshift-certified-operators.yml
@@ -8,5 +8,5 @@ spec:
   source:
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/certified-operator-index:v4.19
+      ref: registry.redhat.io/redhat/certified-operator-index:v4.18
     type: Image

--- a/openshift/catalogd/manifests/20-clustercatalog-openshift-community-operators.yml
+++ b/openshift/catalogd/manifests/20-clustercatalog-openshift-community-operators.yml
@@ -8,5 +8,5 @@ spec:
   source:
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/community-operator-index:v4.19
+      ref: registry.redhat.io/redhat/community-operator-index:v4.18
     type: Image

--- a/openshift/catalogd/manifests/21-clustercatalog-openshift-redhat-marketplace.yml
+++ b/openshift/catalogd/manifests/21-clustercatalog-openshift-redhat-marketplace.yml
@@ -8,5 +8,5 @@ spec:
   source:
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.19
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.18
     type: Image

--- a/openshift/catalogd/manifests/22-clustercatalog-openshift-redhat-operators.yml
+++ b/openshift/catalogd/manifests/22-clustercatalog-openshift-redhat-operators.yml
@@ -8,5 +8,5 @@ spec:
   source:
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-operator-index:v4.19
+      ref: registry.redhat.io/redhat/redhat-operator-index:v4.18
     type: Image


### PR DESCRIPTION
This reverts commit a98980b70ca781ee96379e3b999515fe8189d200.