### PR TITLE
NO-ISSUE: <carry>: fix: set NoLchown=true to allow image unpack on OCPci

### DIFF
--- a/openshift/default-catalog-consistency/pkg/extract/extract.go
+++ b/openshift/default-catalog-consistency/pkg/extract/extract.go
@@ -176,6 +176,9 @@ func extractLayers(ctx context.Context, layoutPath, fsPath, tag string) error {
 		mask := os.FileMode(0755)
 		opts := &archive.TarOptions{
 			ForceMask: &mask,
+			// Required to avoid permission errors when extracting the layers in the OCP CI environment.
+			// extract filesystem: apply layer 0: lchown /tmp/.../afs: operation not permitted
+			NoLchown: true,
 		}
 
 		_, err = archive.ApplyUncompressedLayer(fsPath, decompress, opts)


### PR DESCRIPTION
The change is required to allow the tests run in the OCP/ci. See that we are facing the error:

```
Will run [1m4[0m of [1m4[0m specs
Using registry auth file: /var/run/secrets/ci.openshift.io/cluster-profile/pull-secret
no default policy found for (registry.redhat.io/redhat/certified-operator-index:v4.18), using insecure policy
[38;5;243m------------------------------[0m
[38;5;9m• [FAILED] [3.087 seconds][0m
[0mCheck Catalog Consistency [38;5;9m[1m[It] validates image: certified-operator-index[0m
[38;5;243m/go/src/github.com/openshift/operator-framework-operator-controller/openshift/default-catalog-consistency/test/validate/suite_test.go:30[0m

  [38;5;243mTimeline >>[0m
  [1mSTEP:[0m Validating image: registry.redhat.io/redhat/certified-operator-index:v4.18 [38;5;243m@ 05/19/25 13:04:30.923[0m
  [38;5;9m[FAILED][0m in [It] - /go/src/github.com/openshift/operator-framework-operator-controller/openshift/default-catalog-consistency/test/validate/suite_test.go:35 [38;5;243m@ 05/19/25 13:04:34.009[0m
  [38;5;243m<< Timeline[0m

  [38;5;9m[FAILED] Unexpected error:
      <*fmt.wrapError | 0xc0005a6040>: 
      extract filesystem: apply layer 0: lchown /tmp/oci-certified-operator-index-3726979694/fs/afs: operation not permitted
      {
          msg: "extract filesystem: apply layer 0: lchown /tmp/oci-certified-operator-index-3726979694/fs/afs: operation not permitted",
          err: <*fmt.wrapError | 0xc0005a6020>{
              msg: "apply layer 0: lchown /tmp/oci-certified-operator-index-3726979694/fs/afs: operation not permitted",
              err: <*fs.PathError | 0xc0005a4060>{
                  Op: "lchown",
                  Path: "/tmp/oci-certified-operator-index-3726979694/fs/afs",
                  Err: <syscall.Errno>0x1,
              },
          },
      }
  occurred[0m

```
