### PR TITLE
NO-ISSUE: [Default Catalog]: Create tmp dir to extract layers with right permissions to avoid issues scenarios

### DIFF
--- a/openshift/default-catalog-consistency/pkg/extract/extract.go
+++ b/openshift/default-catalog-consistency/pkg/extract/extract.go
@@ -88,6 +88,13 @@ func UnpackImage(ctx context.Context, imageRef, name string, sysCtx *types.Syste
 
 		// Create and use a separate fs directory for unpacked layers
 		fsDir := filepath.Join(tmpDir, "fs")
+
+		// Create the fs directory and set permissions
+		// To avoid permissions issues scenarios
+		if err := os.MkdirAll(fsDir, 0o755); err != nil {
+			return nil, fmt.Errorf("make fs dir to unpack: %w", err)
+		}
+
 		if err := extractLayers(ctx, ociDir, fsDir, digestTag); err != nil {
 			return nil, fmt.Errorf("extract filesystem: %w", err)
 		}


### PR DESCRIPTION
This change is to allow us to integrate with the OCP periodic (https://github.com/openshift/release/pull/65050)
We have been facing issues:

```
Will run [1m4[0m of [1m4[0m specs
no default policy found for (registry.redhat.io/redhat/certified-operator-index:v4.18), using insecure policy
[38;5;243m------------------------------[0m
[38;5;9m• [FAILED] [7.154 seconds][0m
[0mCheck Catalog Consistency [38;5;9m[1m[It] validates image: certified-operator-index[0m
[38;5;243m/go/src/github.com/openshift/operator-framework-operator-controller/openshift/default-catalog-consistency/test/validate/suite_test.go:53[0m

  [38;5;243mTimeline >>[0m
  [1mSTEP:[0m Validating image: registry.redhat.io/redhat/certified-operator-index:v4.18 [38;5;243m@ 05/20/25 15:37:22.142[0m
  [38;5;9m[FAILED][0m in [It] - /go/src/github.com/openshift/operator-framework-operator-controller/openshift/default-catalog-consistency/test/validate/suite_test.go:58 [38;5;243m@ 05/20/25 15:37:29.296[0m
  [38;5;243m<< Timeline[0m

  [38;5;9m[FAILED] Unexpected error:
      <*fmt.wrapError | 0xc00084a040>: 
      extract filesystem: apply layer 0: lchown /alabama/oci-tmp/oci-certified-operator-index-2181798387/fs/afs: operation not permitted
      {
          msg: "extract filesystem: apply layer 0: lchown /alabama/oci-tmp/oci-certified-operator-index-2181798387/fs/afs: operation not permitted",
          err: <*fmt.wrapError | 0xc00084a020>{
              msg: "apply layer 0: lchown /alabama/oci-tmp/oci-certified-operator-index-2181798387/fs/afs: operation not permitted",
              err: <*fs.PathError | 0xc0001282a0>{
                  Op: "lchown",
                  Path: "/alabama/oci-tmp/oci-certified-operator-index-2181798387/fs/afs",
                  Err: <syscall.Errno>0x1,
              },
          },
      }
```
