### PR TITLE
OCPBUGS-56569: [release-4.18] fix: don't template registry+v1 manifests

### DIFF
--- a/internal/rukpak/convert/registryv1.go
+++ b/internal/rukpak/convert/registryv1.go
@@ -172,9 +172,21 @@ func toChart(in RegistryV1, installNamespace string, watchNamespaces []string) (
 			return nil, err
 		}
 		hash := sha256.Sum256(jsonData)
-		chrt.Templates = append(chrt.Templates, &chart.File{
-			Name: fmt.Sprintf("object-%x.json", hash[0:8]),
+		name := fmt.Sprintf("object-%x.json", hash[0:8])
+
+		// Some registry+v1 manifests may actually contain Go Template strings
+		// that are meant to survive and actually persist into etcd (e.g. to be
+		// used as a templated configuration for another component). In order to
+		// avoid applying templating logic to registry+v1's static manifests, we
+		// create the manifests as Files, and then template those files via simple
+		// Templates.
+		chrt.Files = append(chrt.Files, &chart.File{
+			Name: name,
 			Data: jsonData,
+		})
+		chrt.Templates = append(chrt.Templates, &chart.File{
+			Name: name,
+			Data: []byte(fmt.Sprintf(`{{.Files.Get "%s"}}`, name)),
 		})
 	}
 

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -354,6 +354,12 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 					assert.NotEmpty(ct, clusterExtension.Status.Install.Bundle)
 				}
 			}, pollDuration, pollInterval)
+
+			t.Log("By verifying that no templating occurs for registry+v1 bundle manifests")
+			cm := corev1.ConfigMap{}
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: ns.Name, Name: "test-configmap"}, &cm))
+			require.Contains(t, cm.Annotations, "shouldNotTemplate")
+			require.Contains(t, cm.Annotations["shouldNotTemplate"], "{{ $labels.namespace }}")
 		})
 	}
 }

--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/bundle.configmap.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/bundle.configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-configmap
+  annotations:
+    shouldNotTemplate: >
+      The namespace is {{ $labels.namespace }}. The templated
+      $labels.namespace is NOT expected to be processed by OLM's
+      rendering engine for registry+v1 bundles.
 data:
   version: "v1.0.0"
   name: "test-configmap"


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/operator-framework-operator-controller/pull/353