### PR TITLE
OCPBUGS-55918: set SELinux type for operator-controller

### DIFF
--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -22,3 +22,6 @@
 - op: add
   path: /spec/template/spec/containers/0/env
   value: [{"name":"SSL_CERT_DIR", "value":"/var/ca-certs"}]
+- op: add
+  path: /spec/template/spec/securityContext/seLinuxOptions
+  value: {"type":"spc_t"}

--- a/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -97,6 +97,8 @@ spec:
         node-role.kubernetes.io/master: ""
       securityContext:
         runAsNonRoot: true
+        seLinuxOptions:
+          type: spc_t
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: operator-controller-controller-manager


### PR DESCRIPTION
Fix the `operator-controller` part, the same as #329
```go
 jiazha-mac:~ jiazha$ oc exec operator-controller-controller-manager-78f674f5f8-ww74h -- ls -R /etc/docker 
ls: cannot open directory '/etc/docker': Permission denied
command terminated with exit code 2
```