### PR TITLE
OCPBUGS-56956, OPRUN-3914:  [Default Catalog Consistency Test]: fix junit output format to allow generate xml

### DIFF
--- a/openshift/default-catalog-consistency/.gitignore
+++ b/openshift/default-catalog-consistency/.gitignore
@@ -1,0 +1,2 @@
+# Binaries for programs and plugins
+bin/*

--- a/openshift/default-catalog-consistency/Makefile
+++ b/openshift/default-catalog-consistency/Makefile
@@ -23,10 +23,26 @@ help: #HELP Display essential help.
 
 #SECTION Tests
 
+# Set the Ginkgo binary path. Assumes it's installed via `go install`
+GOBIN ?= $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+  GOBIN := $(shell go env GOPATH)/bin
+endif
+
+TOOLS_BIN_DIR := $(CURDIR)/bin
+GINKGO := $(TOOLS_BIN_DIR)/ginkgo
+
+.PHONY: install-tools
+install-tools: $(GINKGO) #HELP Build vendored CLI tools
+
+$(GINKGO): vendor/modules.txt
+	go build -mod=vendor -o $(GINKGO) ./vendor/github.com/onsi/ginkgo/v2/ginkgo
+
 .PHONY: test-catalog
-test-catalog: #HELP Run the set of tests to validate the quality of catalogs
-	E2E_GINKGO_OPTS="$(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') --junit-report junit_e2e.xml" \
-	go test -count=1 -v ./test/validate/...;
+test-catalog: install-tools $(GINKGO) #HELP Run the set of tests to validate the quality of catalogs
+	$(GINKGO) $(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') \
+		--junit-report=junit_olm.xml ./test/validate/...
+
 
 #SECTION Development
 


### PR DESCRIPTION
See: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_operator-framework-operator-controller/366/pull-ci-openshift-operator-framework-operator-controller-main-default-catalog-consistency/1929498213128081408/artifacts/default-catalog-consistency/default-catalog-tests/artifacts/junit_olm.xml

/cherrypick release-4.19 release-4.18 release-4.17



