### PR TITLE
OCPBUGS-57019 OPRUN-3946: [Default Catalog Consistency Test]: cleanups and enhancements: Add output xml to the gitignore and remove unused code from Makefile

### DIFF
--- a/openshift/default-catalog-consistency/.gitignore
+++ b/openshift/default-catalog-consistency/.gitignore
@@ -1,2 +1,5 @@
 # Binaries for programs and plugins
 bin/*
+
+# Output from tests
+*.xml

--- a/openshift/default-catalog-consistency/Makefile
+++ b/openshift/default-catalog-consistency/Makefile
@@ -22,13 +22,6 @@ help: #HELP Display essential help.
 	@awk 'BEGIN {FS = ":[^#]*#HELP"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\n"} /^[a-zA-Z_0-9-]+:.*#HELP / { printf "  \033[36m%-17s\033[0m %s\n", $$1, $$2 } ' $(MAKEFILE_LIST)
 
 #SECTION Tests
-
-# Set the Ginkgo binary path. Assumes it's installed via `go install`
-GOBIN ?= $(shell go env GOBIN)
-ifeq ($(GOBIN),)
-  GOBIN := $(shell go env GOPATH)/bin
-endif
-
 TOOLS_BIN_DIR := $(CURDIR)/bin
 GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 

--- a/openshift/default-catalog-consistency/test/validate/suite_test.go
+++ b/openshift/default-catalog-consistency/test/validate/suite_test.go
@@ -19,10 +19,10 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Validate Catalog Test Suite")
+	RunSpecs(t, "OLM-Catalog-Validation")
 }
 
-var _ = Describe("Check Catalog Consistency", func() {
+var _ = Describe("OLM-Catalog-Validation", func() {
 	catalogsPath := "../../../catalogd/kustomize/overlays/openshift/catalogs"
 	images, err := utils.ParseImageRefsFromCatalog(catalogsPath)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
- Rename the suite tests to: `OLM-Catalog-Validation` do address the TRT request
     - See: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1749049667418439?thread_ts=1748434430.004709&cid=C01CQA76KMX
     Now we have: `<testsuite name="OLM-Catalog-Validation"`
- Addressing nit cleanups: add gitignore and remove code unused from Makefile

