### PR TITLE
 [Default Catalog Consistency Test]: Cherry-Picks 

### DIFF
--- a/openshift/default-catalog-consistency/.gitignore
+++ b/openshift/default-catalog-consistency/.gitignore
@@ -1,2 +1,5 @@
 # Binaries for programs and plugins
 bin/*
+
+# Output from tests
+*.xml

--- a/openshift/default-catalog-consistency/.gitignore
+++ b/openshift/default-catalog-consistency/.gitignore
@@ -1,0 +1,2 @@
+# Binaries for programs and plugins
+bin/*

--- a/openshift/default-catalog-consistency/Makefile
+++ b/openshift/default-catalog-consistency/Makefile
@@ -23,10 +23,26 @@ help: #HELP Display essential help.
 
 #SECTION Tests
 
+# Set the Ginkgo binary path. Assumes it's installed via `go install`
+GOBIN ?= $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+  GOBIN := $(shell go env GOPATH)/bin
+endif
+
+TOOLS_BIN_DIR := $(CURDIR)/bin
+GINKGO := $(TOOLS_BIN_DIR)/ginkgo
+
+.PHONY: install-tools
+install-tools: $(GINKGO) #HELP Build vendored CLI tools
+
+$(GINKGO): vendor/modules.txt
+	go build -mod=vendor -o $(GINKGO) ./vendor/github.com/onsi/ginkgo/v2/ginkgo
+
 .PHONY: test-catalog
-test-catalog: #HELP Run the set of tests to validate the quality of catalogs
-	E2E_GINKGO_OPTS="$(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') --junit-report junit_e2e.xml" \
-	go test -count=1 -v ./test/validate/...;
+test-catalog: install-tools $(GINKGO) #HELP Run the set of tests to validate the quality of catalogs
+	$(GINKGO) $(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') \
+		--junit-report=junit_olm.xml ./test/validate/...
+
 
 #SECTION Development
 

--- a/openshift/default-catalog-consistency/Makefile
+++ b/openshift/default-catalog-consistency/Makefile
@@ -22,13 +22,6 @@ help: #HELP Display essential help.
 	@awk 'BEGIN {FS = ":[^#]*#HELP"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\n"} /^[a-zA-Z_0-9-]+:.*#HELP / { printf "  \033[36m%-17s\033[0m %s\n", $$1, $$2 } ' $(MAKEFILE_LIST)
 
 #SECTION Tests
-
-# Set the Ginkgo binary path. Assumes it's installed via `go install`
-GOBIN ?= $(shell go env GOBIN)
-ifeq ($(GOBIN),)
-  GOBIN := $(shell go env GOPATH)/bin
-endif
-
 TOOLS_BIN_DIR := $(CURDIR)/bin
 GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 

--- a/openshift/default-catalog-consistency/pkg/check/all.go
+++ b/openshift/default-catalog-consistency/pkg/check/all.go
@@ -5,8 +5,6 @@ func AllChecks() Checks {
 	return Checks{
 		ImageChecks:      AllImageChecks(),
 		FilesystemChecks: AllFilesystemChecks(),
-		// TODO: Enable those tests when community-operator-index and certified-operator-index
-		// have the issues fixed, see: https://issues.redhat.com/browse/CLOUDWF-11022
-		// CatalogChecks: AllCatalogChecks(),
+		CatalogChecks:    AllCatalogChecks(),
 	}
 }

--- a/openshift/default-catalog-consistency/test/validate/suite_test.go
+++ b/openshift/default-catalog-consistency/test/validate/suite_test.go
@@ -18,10 +18,10 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Validate Catalog Test Suite")
+	RunSpecs(t, "OLM-Catalog-Validation")
 }
 
-var _ = Describe("Check Catalog Consistency", func() {
+var _ = Describe("OLM-Catalog-Validation", func() {
 	catalogsPath := "../../../catalogd/kustomize/overlays/openshift/catalogs"
 	images, err := utils.ParseImageRefsFromCatalog(catalogsPath)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
- Fix JUnit output format to allow generating XML: https://github.com/openshift/operator-framework-operator-controller/pull/366 (we need to change the output so that it can be integrated with Sippy in a way that allows them to raise alerts when things go wrong). Sippy understands this JUnit format. 
- Rename the tests suite for a name requested by TRT: https://github.com/openshift/operator-framework-operator-controller/pull/372
- Enable Catalog Tests since those are not passing in those tests and pipeline fix the issues: https://github.com/openshift/operator-framework-operator-controller/pull/371
