### PR TITLE
[release-4.18] OCPBUGS-57019: [Default Catalog Consistency Test]: Cherry-picks for Catalog Tests: Fix JUnit format, rename test suite, and enable Catalog Tests for Sippy/TRT integration 

### DIFF
--- a/openshift/default-catalog-consistency/.gitignore
+++ b/openshift/default-catalog-consistency/.gitignore
@@ -1,2 +1,5 @@
 # Binaries for programs and plugins
 bin/*
+
+# Output from tests
+*.xml

--- a/openshift/default-catalog-consistency/.gitignore
+++ b/openshift/default-catalog-consistency/.gitignore
@@ -1,0 +1,2 @@
+# Binaries for programs and plugins
+bin/*

--- a/openshift/default-catalog-consistency/Makefile
+++ b/openshift/default-catalog-consistency/Makefile
@@ -23,10 +23,26 @@ help: #HELP Display essential help.
 
 #SECTION Tests
 
+# Set the Ginkgo binary path. Assumes it's installed via `go install`
+GOBIN ?= $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+  GOBIN := $(shell go env GOPATH)/bin
+endif
+
+TOOLS_BIN_DIR := $(CURDIR)/bin
+GINKGO := $(TOOLS_BIN_DIR)/ginkgo
+
+.PHONY: install-tools
+install-tools: $(GINKGO) #HELP Build vendored CLI tools
+
+$(GINKGO): vendor/modules.txt
+	go build -mod=vendor -o $(GINKGO) ./vendor/github.com/onsi/ginkgo/v2/ginkgo
+
 .PHONY: test-catalog
-test-catalog: #HELP Run the set of tests to validate the quality of catalogs
-	E2E_GINKGO_OPTS="$(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') --junit-report junit_e2e.xml" \
-	go test -count=1 -v ./test/validate/...;
+test-catalog: install-tools $(GINKGO) #HELP Run the set of tests to validate the quality of catalogs
+	$(GINKGO) $(if $(ARTIFACT_DIR),--output-dir='$(ARTIFACT_DIR)') \
+		--junit-report=junit_olm.xml ./test/validate/...
+
 
 #SECTION Development
 

--- a/openshift/default-catalog-consistency/Makefile
+++ b/openshift/default-catalog-consistency/Makefile
@@ -22,13 +22,6 @@ help: #HELP Display essential help.
 	@awk 'BEGIN {FS = ":[^#]*#HELP"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\n"} /^[a-zA-Z_0-9-]+:.*#HELP / { printf "  \033[36m%-17s\033[0m %s\n", $$1, $$2 } ' $(MAKEFILE_LIST)
 
 #SECTION Tests
-
-# Set the Ginkgo binary path. Assumes it's installed via `go install`
-GOBIN ?= $(shell go env GOBIN)
-ifeq ($(GOBIN),)
-  GOBIN := $(shell go env GOPATH)/bin
-endif
-
 TOOLS_BIN_DIR := $(CURDIR)/bin
 GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 

--- a/openshift/default-catalog-consistency/pkg/check/all.go
+++ b/openshift/default-catalog-consistency/pkg/check/all.go
@@ -5,8 +5,6 @@ func AllChecks() Checks {
 	return Checks{
 		ImageChecks:      AllImageChecks(),
 		FilesystemChecks: AllFilesystemChecks(),
-		// TODO: Enable those tests when community-operator-index and certified-operator-index
-		// have the issues fixed, see: https://issues.redhat.com/browse/CLOUDWF-11022
-		// CatalogChecks: AllCatalogChecks(),
+		CatalogChecks:    AllCatalogChecks(),
 	}
 }

--- a/openshift/default-catalog-consistency/test/validate/suite_test.go
+++ b/openshift/default-catalog-consistency/test/validate/suite_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Validate Catalog Test Suite")
+	RunSpecs(t, "OLM-Catalog-Validation")
 }
 
 // images is a list of image references to be validated.
@@ -29,7 +29,7 @@ var images = []string{
 	"registry.redhat.io/redhat/redhat-operator-index:v4.18",
 }
 
-var _ = Describe("Check Catalog Consistency", func() {
+var _ = Describe("OLM-Catalog-Validation", func() {
 	authPath := os.Getenv("REGISTRY_AUTH_FILE")
 
 	// Force image resolution to Linux to avoid OS mismatch errors on macOS,


### PR DESCRIPTION
Cherry-pick of: https://github.com/openshift/operator-framework-operator-controller/pull/374/files manually to solve the conflict with the latest commit to rename the suite test. 

```
$ git cherry-pick 180a863fb28fbd9a9c2e5a7a91ed20e90e6804ca
Auto-merging openshift/default-catalog-consistency/test/validate/suite_test.go
CONFLICT (content): Merge conflict in openshift/default-catalog-consistency/test/validate/suite_test.go
error: could not apply 180a863f... UPSTREAM: <carry>: [Default Catalog Consistency Test]: Rename Tests suite and small cleanups
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".
hint: Disable this message with "git config advice.mergeConflict false"
```

See; https://github.com/openshift/operator-framework-operator-controller/pull/374#issuecomment-2956019854

/cherrypick release-4.17