### PR TITLE
NO-ISSUE: Update e2e registry to use 1.24/4.20

### DIFF
--- a/openshift/registry.Dockerfile
+++ b/openshift/registry.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /build
 COPY . .
 # TODO Modify upstream Makefile to separate the 'go build' commands
@@ -6,7 +6,7 @@ COPY . .
 RUN go build -o ./registry ./testdata/registry/registry.go
 RUN go build -o ./push     ./testdata/push/push.go
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 USER 1001
 COPY --from=builder /build/registry /registry
 COPY --from=builder /build/push /push


### PR DESCRIPTION
Update the e2e registry Dockerfile to use golang 1.24/OCP 4.20