### PR TITLE
OPRUN-3969: Add support for experimental manifests

### DIFF
--- a/openshift/catalogd.Dockerfile
+++ b/openshift/catalogd.Dockerfile
@@ -6,7 +6,9 @@ RUN make go-build-local
 FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 USER 1001
 COPY --from=builder /build/bin/catalogd /catalogd
+COPY openshift/catalogd/cp-manifests /cp-manifests
 COPY openshift/catalogd/manifests /openshift/manifests
+COPY openshift/catalogd/manifests-experimental /openshift/manifests-experimental
 
 LABEL io.k8s.display-name="OpenShift Operator Lifecycle Manager Catalog Controller" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides operator catalog support."

--- a/openshift/catalogd/cp-manifests
+++ b/openshift/catalogd/cp-manifests
@@ -14,6 +14,6 @@ fi
 
 if [ -d /openshift/manifests-experimental ]; then
     mkdir -p "${DEST}/experimental/catalogd"
-    cp -a /openshift/manifests "${DEST}/experimental/catalogd"
+    cp -a /openshift/manifests-experimental "${DEST}/experimental/catalogd"
 fi
 

--- a/openshift/catalogd/cp-manifests
+++ b/openshift/catalogd/cp-manifests
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ -z "${1}" ]; then
+   echo "No destination specified"
+   exit 1
+fi
+
+DEST=${1}
+
+if [ -d /openshift/manifests ]; then
+    mkdir -p "${DEST}/standard/catalogd"
+    cp -a /openshift/manifests "${DEST}/standard/catalogd"
+fi
+
+if [ -d /openshift/manifests-experimental ]; then
+    mkdir -p "${DEST}/experimental/catalogd"
+    cp -a /openshift/manifests "${DEST}/experimental/catalogd"
+fi
+

--- a/openshift/catalogd/generate-manifests.sh
+++ b/openshift/catalogd/generate-manifests.sh
@@ -44,88 +44,98 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # Source bingo so we can use kustomize and yq
 . "${REPO_ROOT}/openshift/.bingo/variables.env"
 
-# We're going to do file manipulation, so let's work in a temp dir
-TMP_ROOT="$(mktemp -p . -d 2>/dev/null || mktemp -d ./tmpdir.XXXXXXX)"
-# Make sure to delete the temp dir when we exit
-trap 'rm -rf $TMP_ROOT' EXIT
+# This function generates the manifests
+generate () {
+    INPUT_DIR=${1}
+    OUTPUT_DIR=${2}
+    # We're going to do file manipulation, so let's work in a temp dir
+    TMP_ROOT="$(mktemp -p . -d 2>/dev/null || mktemp -d ./tmpdir.XXXXXXX)"
+    # Make sure to delete the temp dir when we exit
+    trap 'rm -rf $TMP_ROOT' EXIT
 
-# Copy all kustomize files into a temp dir
-cp -a "${REPO_ROOT}/config/" "${TMP_ROOT}/config/"
+    # Copy all kustomize files into a temp dir
+    cp -a "${REPO_ROOT}/config/" "${TMP_ROOT}/config/"
 
-mkdir -p "${TMP_ROOT}/openshift/catalogd/"
-cp -a "${REPO_ROOT}/openshift/catalogd/kustomize" "${TMP_ROOT}/openshift/catalogd/kustomize"
+    mkdir -p "${TMP_ROOT}/openshift/catalogd/"
+    cp -a "${REPO_ROOT}/openshift/catalogd/kustomize" "${TMP_ROOT}/openshift/catalogd/kustomize"
 
-# Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
-find "${TMP_ROOT}" -name "*.yaml" -exec sed -i'.bak' "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
-find "${TMP_ROOT}" -name "*.bak" -exec rm {} \;
+    # Override OPENSHIFT-NAMESPACE to ${NAMESPACE}
+    find "${TMP_ROOT}" -name "*.yaml" -exec sed -i'.bak' "s/OPENSHIFT-NAMESPACE/${NAMESPACE}/g" {} \;
+    find "${TMP_ROOT}" -name "*.bak" -exec rm {} \;
 
-# Create a temp dir for manifests
-TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"
-mkdir -p "$TMP_MANIFEST_DIR"
+    # Create a temp dir for manifests
+    TMP_MANIFEST_DIR="${TMP_ROOT}/manifests"
+    mkdir -p "$TMP_MANIFEST_DIR"
 
-# Run kustomize, which emits a single yaml file
-TMP_KUSTOMIZE_OUTPUT="${TMP_MANIFEST_DIR}/temp.yaml"
-$KUSTOMIZE build "${TMP_ROOT}/openshift/catalogd/kustomize/overlays/openshift" -o "$TMP_KUSTOMIZE_OUTPUT"
+    # Run kustomize, which emits a single yaml file
+    TMP_KUSTOMIZE_OUTPUT="${TMP_MANIFEST_DIR}/temp.yaml"
+    $KUSTOMIZE build "${TMP_ROOT}/openshift/catalogd/kustomize/overlays/${INPUT_DIR}" -o "$TMP_KUSTOMIZE_OUTPUT"
 
-for container_name in "${!IMAGE_MAPPINGS[@]}"; do
-  placeholder="${IMAGE_MAPPINGS[$container_name]}"
-  $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.containers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
-  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
-  $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "privileged"}' "$TMP_KUSTOMIZE_OUTPUT"
-  $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"
-done
+    for container_name in "${!IMAGE_MAPPINGS[@]}"; do
+        placeholder="${IMAGE_MAPPINGS[$container_name]}"
+        $YQ -i "(select(.kind == \"Deployment\")|.spec.template.spec.containers[]|select(.name==\"$container_name\")|.image) = \"$placeholder\"" "$TMP_KUSTOMIZE_OUTPUT"
+        $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"}' "$TMP_KUSTOMIZE_OUTPUT"
+        $YQ -i 'select(.kind == "Deployment").spec.template.metadata.annotations += {"openshift.io/required-scc": "privileged"}' "$TMP_KUSTOMIZE_OUTPUT"
+        $YQ -i 'select(.kind == "Deployment").spec.template.spec += {"priorityClassName": "system-cluster-critical"}' "$TMP_KUSTOMIZE_OUTPUT"
+    done
 
-# Loop through any flag updates that need to be made to the manager container
-for flag_name in "${!FLAG_MAPPINGS[@]}"; do
-  flagval="${FLAG_MAPPINGS[$flag_name]}"
+    # Loop through any flag updates that need to be made to the manager container
+    for flag_name in "${!FLAG_MAPPINGS[@]}"; do
+        flagval="${FLAG_MAPPINGS[$flag_name]}"
 
-  # First, update the flag if it exists
-  $YQ -i "(select(.kind == \"Deployment\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .args[] | select(. | contains(\"--$flag_name=\")) | .) = \"--$flag_name=$flagval\"" "$TMP_KUSTOMIZE_OUTPUT"
+        # First, update the flag if it exists
+        $YQ -i "(select(.kind == \"Deployment\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .args[] | select(. | contains(\"--$flag_name=\")) | .) = \"--$flag_name=$flagval\"" "$TMP_KUSTOMIZE_OUTPUT"
 
-  # Then, append the flag if it doesn't exist
-  $YQ -i "(select(.kind == \"Deployment\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .args) |= (select(.[] | contains(\"--$flag_name=\")) | .) // . + [\"--$flag_name=$flagval\"]" "$TMP_KUSTOMIZE_OUTPUT"
-done
+        # Then, append the flag if it doesn't exist
+        $YQ -i "(select(.kind == \"Deployment\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .args) |= (select(.[] | contains(\"--$flag_name=\")) | .) // . + [\"--$flag_name=$flagval\"]" "$TMP_KUSTOMIZE_OUTPUT"
+    done
 
-# Use yq to split the single yaml file into 1 per document.
-# Naming convention: $index-$kind-$namespace-$name. If $namespace is empty, just use the empty string.
-(
-  cd "$TMP_MANIFEST_DIR"
+    # Use yq to split the single yaml file into 1 per document.
+    # Naming convention: $index-$kind-$namespace-$name. If $namespace is empty, just use the empty string.
+    (
+        cd "$TMP_MANIFEST_DIR"
 
-  # shellcheck disable=SC2016
-  ${YQ} -s '$index +"-"+ (.kind|downcase) +"-"+ (.metadata.namespace // "") +"-"+ .metadata.name' temp.yaml
-)
+        # shellcheck disable=SC2016
+        ${YQ} -s '$index +"-"+ (.kind|downcase) +"-"+ (.metadata.namespace // "") +"-"+ .metadata.name' temp.yaml
+    )
 
-# Delete the single yaml file
-rm "$TMP_KUSTOMIZE_OUTPUT"
+    # Delete the single yaml file
+    rm "$TMP_KUSTOMIZE_OUTPUT"
 
-# Delete and recreate the actual manifests directory
-MANIFEST_DIR="${REPO_ROOT}/openshift/catalogd/manifests"
-rm -rf "${MANIFEST_DIR}"
-mkdir -p "${MANIFEST_DIR}"
+    # Delete and recreate the actual manifests directory
+    MANIFEST_DIR="${REPO_ROOT}/openshift/catalogd/${OUTPUT_DIR}"
+    rm -rf "${MANIFEST_DIR}"
+    mkdir -p "${MANIFEST_DIR}"
 
-# Copy everything we just generated and split into the actual manifests directory
-cp "$TMP_MANIFEST_DIR"/* "$MANIFEST_DIR"/
+    # Copy everything we just generated and split into the actual manifests directory
+    cp "$TMP_MANIFEST_DIR"/* "$MANIFEST_DIR"/
 
-# Update file names to be in the format nn-$kind-$namespace-$name
-(
-  cd "$MANIFEST_DIR"
+    # Update file names to be in the format nn-$kind-$namespace-$name
+    (
+        cd "$MANIFEST_DIR"
 
-  for f in *; do
-    # Get the numeric prefix from the filename
-    index=$(echo "$f" | cut -d '-' -f 1)
-    # Keep track of the full file name without the leading number and dash
-    name_without_index=${f#$index-}
-    # Fix the double dash in cluster-scoped names
-    name_without_index=${name_without_index//--/-}
-    # Reformat the name so the leading number is always padded to 2 digits
-    new_name=$(printf "%02d" "$index")-$name_without_index
-    # Some file names (namely CRDs) don't end in .yml - make them
-    if ! [[ "$new_name" =~ yml$ ]]; then
-      new_name="${new_name}".yml
-    fi
-    if [[ "$f" != "$new_name" ]]; then
-      # Rename
-      mv "$f" "${new_name}"
-    fi
-  done
-)
+        for f in *; do
+            # Get the numeric prefix from the filename
+            index=$(echo "$f" | cut -d '-' -f 1)
+            # Keep track of the full file name without the leading number and dash
+            name_without_index=${f#$index-}
+            # Fix the double dash in cluster-scoped names
+            name_without_index=${name_without_index//--/-}
+            # Reformat the name so the leading number is always padded to 2 digits
+            new_name=$(printf "%02d" "$index")-$name_without_index
+            # Some file names (namely CRDs) don't end in .yml - make them
+            if ! [[ "$new_name" =~ yml$ ]]; then
+                new_name="${new_name}".yml
+            fi
+            if [[ "$f" != "$new_name" ]]; then
+                # Rename
+                mv "$f" "${new_name}"
+            fi
+        done
+    )
+    rm -rf "$TMP_ROOT"
+}
+
+# Generate the manifests
+generate openshift manifests
+generate openshift-experimental manifests-experimental

--- a/openshift/catalogd/kustomize/overlays/openshift-experimental/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift-experimental/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- ../../../../../config/base/catalogd/crd/experimental
+- ../openshift/olmv1-ns
+- ../openshift/openshift-config
+- ../openshift/catalogs
+
+# Only those copinents that are part of catalogd TechPreview should be listed here
+components:
+- ../../../../../config/components/features/apiv1-metas-handler

--- a/openshift/catalogd/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- ../../../../../config/base/catalogd/crd/standard
 - olmv1-ns
 - openshift-config
 - catalogs

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
@@ -4,42 +4,10 @@ namespace: OPENSHIFT-NAMESPACE
 namePrefix: catalogd-
 
 resources:
-- ../../../../../../config/base/catalogd/crd
 - ../../../../../../config/base/catalogd/rbac
 - ../../../../../../config/base/catalogd/manager
 - ../../../../../../config/base/common
 - metrics
-- trusted-ca/catalogd_trusted_ca_configmap.yaml
-
-patches:
-- path: patches/manager_namespace_privileged.yaml
-- path: patches/manager_namespace_monitored.yaml
-- path: patches/manager_namespace_annotations.yaml
-- target:
-    kind: Service
-    name: service
-  path: patches/manager_service.yaml
-- target:
-    kind: MutatingWebhookConfiguration
-    name: mutating-webhook-configuration
-  path: patches/mutating_webhook_config.yaml
-- target:
-    kind: ClusterRole
-    name: manager-role
-  path: patches/manager_role.yaml
-- target:
-    kind: Deployment
-    name: controller-manager
-  path: patches/manager_deployment_certs.yaml
-- target:
-    kind: Deployment
-    name: controller-manager
-  path: patches/manager_deployment_mount_etc_containers.yaml
-- target:
-    kind: Deployment
-    name: controller-manager
-  path: patches/manager_deployment_log_verbosity.yaml
-- target:
-    kind: Deployment
-    name: controller-manager
-  path: patches/manager_deployment_node_selection.yaml
+- trusted-ca
+components:
+- patches

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+- path: manager_namespace_privileged.yaml
+- path: manager_namespace_monitored.yaml
+- path: manager_namespace_annotations.yaml
+- target:
+    kind: Service
+    name: service
+  path: manager_service.yaml
+- target:
+    kind: MutatingWebhookConfiguration
+    name: mutating-webhook-configuration
+  path: mutating_webhook_config.yaml
+- target:
+    kind: ClusterRole
+    name: manager-role
+  path: manager_role.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: manager_deployment_certs.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: manager_deployment_mount_etc_containers.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: manager_deployment_log_verbosity.yaml
+- target:
+    kind: Deployment
+    name: controller-manager
+  path: manager_deployment_node_selection.yaml

--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/trusted-ca/kustomization.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/trusted-ca/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- catalogd_trusted_ca_configmap.yaml 

--- a/openshift/catalogd/manifests-experimental/00-namespace-openshift-catalogd.yml
+++ b/openshift/catalogd/manifests-experimental/00-namespace-openshift-catalogd.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: management
+  labels:
+    app.kubernetes.io/part-of: olm
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+  name: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/01-customresourcedefinition-clustercatalogs.olm.operatorframework.io.yml
+++ b/openshift/catalogd/manifests-experimental/01-customresourcedefinition-clustercatalogs.olm.operatorframework.io.yml
@@ -1,0 +1,398 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    olm.operatorframework.io/generator: experimental
+  name: clustercatalogs.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterCatalog
+    listKind: ClusterCatalogList
+    plural: clustercatalogs
+    singular: clustercatalog
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.lastUnpacked
+          name: LastUnpacked
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Serving")].status
+          name: Serving
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ClusterCatalog enables users to make File-Based Catalog (FBC) catalog data available to the cluster.
+            For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                spec is the desired state of the ClusterCatalog.
+                spec is required.
+                The controller will work to ensure that the desired
+                catalog is unpacked and served over the catalog content HTTP server.
+              properties:
+                availabilityMode:
+                  default: Available
+                  description: |-
+                    availabilityMode allows users to define how the ClusterCatalog is made available to clients on the cluster.
+                    availabilityMode is optional.
+
+                    Allowed values are "Available" and "Unavailable" and omitted.
+
+                    When omitted, the default value is "Available".
+
+                    When set to "Available", the catalog contents will be unpacked and served over the catalog content HTTP server.
+                    Setting the availabilityMode to "Available" tells clients that they should consider this ClusterCatalog
+                    and its contents as usable.
+
+                    When set to "Unavailable", the catalog contents will no longer be served over the catalog content HTTP server.
+                    When set to this availabilityMode it should be interpreted the same as the ClusterCatalog not existing.
+                    Setting the availabilityMode to "Unavailable" can be useful in scenarios where a user may not want
+                    to delete the ClusterCatalog all together, but would still like it to be treated as if it doesn't exist.
+                  enum:
+                    - Unavailable
+                    - Available
+                  type: string
+                priority:
+                  default: 0
+                  description: |-
+                    priority allows the user to define a priority for a ClusterCatalog.
+                    priority is optional.
+
+                    A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
+                    A higher number means higher priority.
+
+                    It is up to clients to decide how to handle scenarios where multiple ClusterCatalogs with the same priority meet their requirements.
+                    When deciding how to break the tie in this scenario, it is recommended that clients prompt their users for additional input.
+
+                    When omitted, the default priority is 0 because that is the zero value of integers.
+
+                    Negative numbers can be used to specify a priority lower than the default.
+                    Positive numbers can be used to specify a priority higher than the default.
+
+                    The lowest possible value is -2147483648.
+                    The highest possible value is 2147483647.
+                  format: int32
+                  type: integer
+                source:
+                  description: |-
+                    source allows a user to define the source of a catalog.
+                    A "catalog" contains information on content that can be installed on a cluster.
+                    Providing a catalog source makes the contents of the catalog discoverable and usable by
+                    other on-cluster components.
+                    These on-cluster components may do a variety of things with this information, such as
+                    presenting the content in a GUI dashboard or installing content from the catalog on the cluster.
+                    The catalog source must contain catalog metadata in the File-Based Catalog (FBC) format.
+                    For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs.
+                    source is a required field.
+
+                    Below is a minimal example of a ClusterCatalogSpec that sources a catalog from an image:
+
+                     source:
+                       type: Image
+                       image:
+                         ref: quay.io/operatorhubio/catalog:latest
+                  properties:
+                    image:
+                      description: |-
+                        image is used to configure how catalog contents are sourced from an OCI image.
+                        This field is required when type is Image, and forbidden otherwise.
+                      properties:
+                        pollIntervalMinutes:
+                          description: |-
+                            pollIntervalMinutes allows the user to set the interval, in minutes, at which the image source should be polled for new content.
+                            pollIntervalMinutes is optional.
+                            pollIntervalMinutes can not be specified when ref is a digest-based reference.
+
+                            When omitted, the image will not be polled for new content.
+                          minimum: 1
+                          type: integer
+                        ref:
+                          description: |-
+                            ref allows users to define the reference to a container image containing Catalog contents.
+                            ref is required.
+                            ref can not be more than 1000 characters.
+
+                            A reference can be broken down into 3 parts - the domain, name, and identifier.
+
+                            The domain is typically the registry where an image is located.
+                            It must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                            Hyphenation is allowed, but the domain must start and end with alphanumeric characters.
+                            Specifying a port to use is also allowed by adding the ":" character followed by numeric values.
+                            The port must be the last value in the domain.
+                            Some examples of valid domain values are "registry.mydomain.io", "quay.io", "my-registry.io:8080".
+
+                            The name is typically the repository in the registry where an image is located.
+                            It must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                            Multiple names can be concatenated with the "/" character.
+                            The domain and name are combined using the "/" character.
+                            Some examples of valid name values are "operatorhubio/catalog", "catalog", "my-catalog.prod".
+                            An example of the domain and name parts of a reference being combined is "quay.io/operatorhubio/catalog".
+
+                            The identifier is typically the tag or digest for an image reference and is present at the end of the reference.
+                            It starts with a separator character used to distinguish the end of the name and beginning of the identifier.
+                            For a digest-based reference, the "@" character is the separator.
+                            For a tag-based reference, the ":" character is the separator.
+                            An identifier is required in the reference.
+
+                            Digest-based references must contain an algorithm reference immediately after the "@" separator.
+                            The algorithm reference must be followed by the ":" character and an encoded string.
+                            The algorithm must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                            Some examples of valid algorithm values are "sha256", "sha256+b64u", "multihash+base58".
+                            The encoded string following the algorithm must be hex digits (a-f, A-F, 0-9) and must be a minimum of 32 characters.
+
+                            Tag-based references must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters.
+                            The tag must not be longer than 127 characters.
+
+                            An example of a valid digest-based image reference is "quay.io/operatorhubio/catalog@sha256:200d4ddb2a73594b91358fe6397424e975205bfbe44614f5846033cad64b3f05"
+                            An example of a valid tag-based image reference is "quay.io/operatorhubio/catalog:latest"
+                          maxLength: 1000
+                          type: string
+                          x-kubernetes-validations:
+                            - message: must start with a valid domain. valid domains must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                              rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                            - message: a valid name is required. valid names must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                              rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)') != ""
+                            - message: must end with a digest or a tag
+                              rule: self.find('(@.*:)') != "" || self.find(':.*$') != ""
+                            - message: tag is invalid. the tag must not be more than 127 characters
+                              rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'') != "" ? self.find('':.*$'').substring(1).size() <= 127 : true) : true'
+                            - message: tag is invalid. valid tags must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters
+                              rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'') != "" ? self.find('':.*$'').matches('':[\\w][\\w.-]*$'') : true) : true'
+                            - message: digest algorithm is not valid. valid algorithms must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'') : true'
+                            - message: digest is not valid. the encoded string must be at least 32 characters
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size() >= 32 : true'
+                            - message: digest is not valid. the encoded string must only contain hex characters (A-F, a-f, 0-9)
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'') : true'
+                      required:
+                        - ref
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cannot specify pollIntervalMinutes while using digest-based image
+                          rule: 'self.ref.find(''(@.*:)'') != "" ? !has(self.pollIntervalMinutes) : true'
+                    type:
+                      description: |-
+                        type is a reference to the type of source the catalog is sourced from.
+                        type is required.
+
+                        The only allowed value is "Image".
+
+                        When set to "Image", the ClusterCatalog content will be sourced from an OCI image.
+                        When using an image source, the image field must be set and must be the only field defined for this type.
+                      enum:
+                        - Image
+                      type: string
+                  required:
+                    - type
+                  type: object
+                  x-kubernetes-validations:
+                    - message: image is required when source type is Image, and forbidden otherwise
+                      rule: 'has(self.type) && self.type == ''Image'' ? has(self.image) : !has(self.image)'
+              required:
+                - source
+              type: object
+            status:
+              description: |-
+                status contains information about the state of the ClusterCatalog such as:
+                  - Whether or not the catalog contents are being served via the catalog content HTTP server
+                  - Whether or not the ClusterCatalog is progressing to a new state
+                  - A reference to the source from which the catalog contents were retrieved
+              properties:
+                conditions:
+                  description: |-
+                    conditions is a representation of the current state for this ClusterCatalog.
+
+                    The current condition types are Serving and Progressing.
+
+                    The Serving condition is used to represent whether or not the contents of the catalog is being served via the HTTP(S) web server.
+                    When it has a status of True and a reason of Available, the contents of the catalog are being served.
+                    When it has a status of False and a reason of Unavailable, the contents of the catalog are not being served because the contents are not yet available.
+                    When it has a status of False and a reason of UserSpecifiedUnavailable, the contents of the catalog are not being served because the catalog has been intentionally marked as unavailable.
+
+                    The Progressing condition is used to represent whether or not the ClusterCatalog is progressing or is ready to progress towards a new state.
+                    When it has a status of True and a reason of Retrying, there was an error in the progression of the ClusterCatalog that may be resolved on subsequent reconciliation attempts.
+                    When it has a status of True and a reason of Succeeded, the ClusterCatalog has successfully progressed to a new state and is ready to continue progressing.
+                    When it has a status of False and a reason of Blocked, there was an error in the progression of the ClusterCatalog that requires manual intervention for recovery.
+
+                    In the case that the Serving condition is True with reason Available and Progressing is True with reason Retrying, the previously fetched
+                    catalog contents are still being served via the HTTP(S) web server while we are progressing towards serving a new version of the catalog
+                    contents. This could occur when we've initially fetched the latest contents from the source for this catalog and when polling for changes
+                    to the contents we identify that there are updates to the contents.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                lastUnpacked:
+                  description: |-
+                    lastUnpacked represents the last time the contents of the
+                    catalog were extracted from their source format. As an example,
+                    when using an Image source, the OCI image will be pulled and the
+                    image layers written to a file-system backed cache. We refer to the
+                    act of this extraction from the source format as "unpacking".
+                  format: date-time
+                  type: string
+                resolvedSource:
+                  description: resolvedSource contains information about the resolved source based on the source type.
+                  properties:
+                    image:
+                      description: |-
+                        image is a field containing resolution information for a catalog sourced from an image.
+                        This field must be set when type is Image, and forbidden otherwise.
+                      properties:
+                        ref:
+                          description: |-
+                            ref contains the resolved image digest-based reference.
+                            The digest format is used so users can use other tooling to fetch the exact
+                            OCI manifests that were used to extract the catalog contents.
+                          maxLength: 1000
+                          type: string
+                          x-kubernetes-validations:
+                            - message: must start with a valid domain. valid domains must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                              rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                            - message: a valid name is required. valid names must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                              rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)') != ""
+                            - message: must end with a digest
+                              rule: self.find('(@.*:)') != ""
+                            - message: digest algorithm is not valid. valid algorithms must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'') : true'
+                            - message: digest is not valid. the encoded string must be at least 32 characters
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size() >= 32 : true'
+                            - message: digest is not valid. the encoded string must only contain hex characters (A-F, a-f, 0-9)
+                              rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'') : true'
+                      required:
+                        - ref
+                      type: object
+                    type:
+                      description: |-
+                        type is a reference to the type of source the catalog is sourced from.
+                        type is required.
+
+                        The only allowed value is "Image".
+
+                        When set to "Image", information about the resolved image source will be set in the 'image' field.
+                      enum:
+                        - Image
+                      type: string
+                  required:
+                    - image
+                    - type
+                  type: object
+                  x-kubernetes-validations:
+                    - message: image is required when source type is Image, and forbidden otherwise
+                      rule: 'has(self.type) && self.type == ''Image'' ? has(self.image) : !has(self.image)'
+                urls:
+                  description: urls contains the URLs that can be used to access the catalog.
+                  properties:
+                    base:
+                      description: |-
+                        base is a cluster-internal URL that provides endpoints for
+                        accessing the content of the catalog.
+
+                        It is expected that clients append the path for the endpoint they wish
+                        to access.
+
+                        Currently, only a single endpoint is served and is accessible at the path
+                        /api/v1.
+
+                        The endpoints served for the v1 API are:
+                          - /all - this endpoint returns the entirety of the catalog contents in the FBC format
+
+                        As the needs of users and clients of the evolve, new endpoints may be added.
+                      maxLength: 525
+                      type: string
+                      x-kubernetes-validations:
+                        - message: must be a valid URL
+                          rule: isURL(self)
+                        - message: scheme must be either http or https
+                          rule: 'isURL(self) ? (url(self).getScheme() == "http" || url(self).getScheme() == "https") : true'
+                  required:
+                    - base
+                  type: object
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/openshift/catalogd/manifests-experimental/02-serviceaccount-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests-experimental/02-serviceaccount-openshift-catalogd-catalogd-controller-manager.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-controller-manager
+  namespace: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/03-role-openshift-catalogd-catalogd-leader-election-role.yml
+++ b/openshift/catalogd/manifests-experimental/03-role-openshift-catalogd-catalogd-leader-election-role.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-leader-election-role
+  namespace: openshift-catalogd
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/openshift/catalogd/manifests-experimental/04-role-openshift-catalogd-catalogd-manager-role.yml
+++ b/openshift/catalogd/manifests-experimental/04-role-openshift-catalogd-catalogd-manager-role.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: catalogd-manager-role
+  namespace: openshift-catalogd
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/catalogd/manifests-experimental/05-role-openshift-catalogd-catalogd-metrics-monitor-role.yml
+++ b/openshift/catalogd/manifests-experimental/05-role-openshift-catalogd-catalogd-metrics-monitor-role.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-metrics-monitor-role
+  namespace: openshift-catalogd
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/catalogd/manifests-experimental/06-role-openshift-config-catalogd-manager-role.yml
+++ b/openshift/catalogd/manifests-experimental/06-role-openshift-config-catalogd-manager-role.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-manager-role
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/catalogd/manifests-experimental/07-clusterrole-catalogd-manager-role.yml
+++ b/openshift/catalogd/manifests-experimental/07-clusterrole-catalogd-manager-role.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: catalogd-manager-role
+rules:
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clustercatalogs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clustercatalogs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clustercatalogs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/openshift/catalogd/manifests-experimental/08-clusterrole-catalogd-metrics-reader.yml
+++ b/openshift/catalogd/manifests-experimental/08-clusterrole-catalogd-metrics-reader.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/openshift/catalogd/manifests-experimental/09-clusterrole-catalogd-proxy-role.yml
+++ b/openshift/catalogd/manifests-experimental/09-clusterrole-catalogd-proxy-role.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-proxy-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/openshift/catalogd/manifests-experimental/10-rolebinding-openshift-catalogd-catalogd-leader-election-rolebinding.yml
+++ b/openshift/catalogd/manifests-experimental/10-rolebinding-openshift-catalogd-catalogd-leader-election-rolebinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-leader-election-rolebinding
+  namespace: openshift-catalogd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: catalogd-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/11-rolebinding-openshift-catalogd-catalogd-manager-rolebinding.yml
+++ b/openshift/catalogd/manifests-experimental/11-rolebinding-openshift-catalogd-catalogd-manager-rolebinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-manager-rolebinding
+  namespace: openshift-catalogd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: catalogd-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/12-rolebinding-openshift-catalogd-catalogd-metrics-monitor-rolebinding.yml
+++ b/openshift/catalogd/manifests-experimental/12-rolebinding-openshift-catalogd-catalogd-metrics-monitor-rolebinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-metrics-monitor-rolebinding
+  namespace: openshift-catalogd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: catalogd-metrics-monitor-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/openshift/catalogd/manifests-experimental/13-rolebinding-openshift-config-catalogd-manager-rolebinding.yml
+++ b/openshift/catalogd/manifests-experimental/13-rolebinding-openshift-config-catalogd-manager-rolebinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-manager-rolebinding
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: catalogd-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/14-clusterrolebinding-catalogd-manager-rolebinding.yml
+++ b/openshift/catalogd/manifests-experimental/14-clusterrolebinding-catalogd-manager-rolebinding.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: catalogd-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/15-clusterrolebinding-catalogd-proxy-rolebinding.yml
+++ b/openshift/catalogd/manifests-experimental/15-clusterrolebinding-catalogd-proxy-rolebinding.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: catalogd-proxy-role
+subjects:
+  - kind: ServiceAccount
+    name: catalogd-controller-manager
+    namespace: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/16-configmap-openshift-catalogd-catalogd-trusted-ca-bundle.yml
+++ b/openshift/catalogd/manifests-experimental/16-configmap-openshift-catalogd-catalogd-trusted-ca-bundle.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: catalogd-trusted-ca-bundle
+  namespace: openshift-catalogd

--- a/openshift/catalogd/manifests-experimental/17-service-openshift-catalogd-catalogd-service.yml
+++ b/openshift/catalogd/manifests-experimental/17-service-openshift-catalogd-catalogd-service.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: catalogserver-cert
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: catalogd-service
+  namespace: openshift-catalogd
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    - name: webhook
+      port: 9443
+      protocol: TCP
+      targetPort: 9443
+    - name: metrics
+      port: 7443
+      protocol: TCP
+      targetPort: 7443
+  selector:
+    control-plane: catalogd-controller-manager

--- a/openshift/catalogd/manifests-experimental/18-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests-experimental/18-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -1,0 +1,159 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubectl.kubernetes.io/default-logs-container: manager
+  labels:
+    control-plane: catalogd-controller-manager
+  name: catalogd-controller-manager
+  namespace: openshift-catalogd
+spec:
+  minReadySeconds: 5
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+      labels:
+        control-plane: catalogd-controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - ppc64le
+                      - s390x
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - args:
+            - --leader-elect
+            - --metrics-bind-address=:7443
+            - --external-address=catalogd-service.openshift-catalogd.svc
+            - --tls-cert=/var/certs/tls.crt
+            - --tls-key=/var/certs/tls.key
+            - --v=${LOG_VERBOSITY}
+            - --feature-gates=APIV1MetasHandler=true
+            - --global-pull-secret=openshift-config/pull-secret
+          command:
+            - ./catalogd
+          env:
+            - name: SSL_CERT_DIR
+              value: /var/ca-certs
+          image: ${CATALOGD_IMAGE}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /var/cache/
+              name: cache
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/certs
+              name: catalogserver-certs
+            - mountPath: /var/ca-certs
+              name: ca-certs
+              readOnly: true
+            - mountPath: /etc/containers
+              name: etc-containers
+              readOnly: true
+            - mountPath: /etc/docker
+              name: etc-docker
+              readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        seLinuxOptions:
+          type: spc_t
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: catalogd-controller-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120
+      volumes:
+        - emptyDir: {}
+          name: cache
+        - emptyDir: {}
+          name: tmp
+        - name: catalogserver-certs
+          secret:
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+            optional: false
+            secretName: catalogserver-cert
+        - name: ca-certs
+          projected:
+            sources:
+              - configMap:
+                  items:
+                    - key: ca-bundle.crt
+                      path: ca-bundle.crt
+                  name: catalogd-trusted-ca-bundle
+                  optional: false
+              - configMap:
+                  items:
+                    - key: service-ca.crt
+                      path: service-ca.crt
+                  name: openshift-service-ca.crt
+                  optional: false
+        - hostPath:
+            path: /etc/containers
+            type: Directory
+          name: etc-containers
+        - hostPath:
+            path: /etc/docker
+            type: Directory
+          name: etc-docker
+      priorityClassName: system-cluster-critical

--- a/openshift/catalogd/manifests-experimental/19-servicemonitor-openshift-catalogd-catalogd-metrics-monitor.yml
+++ b/openshift/catalogd/manifests-experimental/19-servicemonitor-openshift-catalogd-catalogd-metrics-monitor.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+    openshift.io/cluster-monitoring: "true"
+  name: catalogd-metrics-monitor
+  namespace: openshift-catalogd
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      path: /metrics
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: catalogd-service.openshift-catalogd.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-catalogd
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: catalogd

--- a/openshift/catalogd/manifests-experimental/20-networkpolicy-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests-experimental/20-networkpolicy-openshift-catalogd-catalogd-controller-manager.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: catalogd-controller-manager
+  namespace: openshift-catalogd
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7443
+          protocol: TCP
+        - port: 8443
+          protocol: TCP
+        - port: 9443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress

--- a/openshift/catalogd/manifests-experimental/21-networkpolicy-openshift-catalogd-catalogd-default-deny-all-traffic.yml
+++ b/openshift/catalogd/manifests-experimental/21-networkpolicy-openshift-catalogd-catalogd-default-deny-all-traffic.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: catalogd-default-deny-all-traffic
+  namespace: openshift-catalogd
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/openshift/catalogd/manifests-experimental/22-clustercatalog-openshift-certified-operators.yml
+++ b/openshift/catalogd/manifests-experimental/22-clustercatalog-openshift-certified-operators.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-certified-operators
+spec:
+  priority: -200
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/certified-operator-index:v4.19
+    type: Image

--- a/openshift/catalogd/manifests-experimental/23-clustercatalog-openshift-community-operators.yml
+++ b/openshift/catalogd/manifests-experimental/23-clustercatalog-openshift-community-operators.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-community-operators
+spec:
+  priority: -400
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/community-operator-index:v4.19
+    type: Image

--- a/openshift/catalogd/manifests-experimental/24-clustercatalog-openshift-redhat-marketplace.yml
+++ b/openshift/catalogd/manifests-experimental/24-clustercatalog-openshift-redhat-marketplace.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-redhat-marketplace
+spec:
+  priority: -300
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.19
+    type: Image

--- a/openshift/catalogd/manifests-experimental/25-clustercatalog-openshift-redhat-operators.yml
+++ b/openshift/catalogd/manifests-experimental/25-clustercatalog-openshift-redhat-operators.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: openshift-redhat-operators
+spec:
+  priority: -100
+  source:
+    image:
+      pollIntervalMinutes: 10
+      ref: registry.redhat.io/redhat/redhat-operator-index:v4.19
+    type: Image

--- a/openshift/catalogd/manifests-experimental/26-mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
+++ b/openshift/catalogd/manifests-experimental/26-mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: catalogd-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: catalogd-service
+        namespace: openshift-catalogd
+        path: /mutate-olm-operatorframework-io-v1-clustercatalog
+        port: 9443
+    failurePolicy: Fail
+    matchConditions:
+      - expression: '''name'' in object.metadata && (!has(object.metadata.labels) || !(''olm.operatorframework.io/metadata.name'' in object.metadata.labels) || object.metadata.labels[''olm.operatorframework.io/metadata.name''] != object.metadata.name)'
+        name: MissingOrIncorrectMetadataNameLabel
+    name: inject-metadata-name.olm.operatorframework.io
+    rules:
+      - apiGroups:
+          - olm.operatorframework.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clustercatalogs
+    sideEffects: None
+    timeoutSeconds: 10

--- a/openshift/operator-controller.Dockerfile
+++ b/openshift/operator-controller.Dockerfile
@@ -6,7 +6,9 @@ RUN make go-build-local
 FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 USER 1001
 COPY --from=builder /build/bin/operator-controller /operator-controller
+COPY openshift/operator-controller/cp-manifests /cp-manifests
 COPY openshift/operator-controller/manifests /openshift/manifests
+COPY openshift/operator-controller/manifests-experimental /openshift/manifests-experimental
 
 LABEL io.k8s.display-name="OpenShift Operator Lifecycle Manager Operator Controller" \
   io.k8s.description="This is a component of OpenShift Container Platform that allows operator installation."

--- a/openshift/operator-controller/cp-manifests
+++ b/openshift/operator-controller/cp-manifests
@@ -14,6 +14,6 @@ fi
 
 if [ -d /openshift/manifests-experimental ]; then
     mkdir -p "${DEST}/experimental/operator-controller"
-    cp -a /openshift/manifests "${DEST}/experimental/operator-controller"
+    cp -a /openshift/manifests-experimental "${DEST}/experimental/operator-controller"
 fi
 

--- a/openshift/operator-controller/cp-manifests
+++ b/openshift/operator-controller/cp-manifests
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ -z "${1}" ]; then
+   echo "No destination specified"
+   exit 1
+fi
+
+DEST=${1}
+
+if [ -d /openshift/manifests ]; then
+    mkdir -p "${DEST}/standard/operator-controller"
+    cp -a /openshift/manifests "${DEST}/standard/operator-controller"
+fi
+
+if [ -d /openshift/manifests-experimental ]; then
+    mkdir -p "${DEST}/experimental/operator-controller"
+    cp -a /openshift/manifests "${DEST}/experimental/operator-controller"
+fi
+

--- a/openshift/operator-controller/kustomize/overlays/openshift-experimental/kustomization.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift-experimental/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+  - ../../../../../config/base/operator-controller/crd/experimental
+  - ../openshift/olmv1-ns
+  - ../openshift/openshift-config
+
+# Only those components that are part of operator-controller TechPreview should be listed here
+components:
+  - ../../../../../config/components/features/preflight-permissions
+  - ../../../../../config/components/features/single-own-namespace
+  - ../../../../../config/components/features/webhook-provider-openshift-serviceca

--- a/openshift/operator-controller/kustomize/overlays/openshift/kustomization.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/kustomization.yaml
@@ -1,5 +1,4 @@
-namePrefix: operator-controller-
-
 resources:
+  - ../../../../../config/base/operator-controller/crd/standard
   - olmv1-ns
   - openshift-config

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/kustomization.yaml
@@ -1,39 +1,13 @@
 # Adds namespace to all resources.
 namespace: OPENSHIFT-NAMESPACE
+namePrefix: operator-controller-
 
 resources:
-  - ../../../../../../config/base/operator-controller/crd
   - ../../../../../../config/base/operator-controller/rbac
   - ../../../../../../config/base/operator-controller/manager
   - ../../../../../../config/base/common
   - metrics
-  - trusted-ca/operator_controller_trusted_ca_configmap.yaml
+  - trusted-ca
 
-patches:
-  - path: patches/manager_namespace_privileged.yaml
-  - path: patches/manager_namespace_monitored.yaml
-  - path: patches/manager_namespace_annotations.yaml
-  - target:
-      kind: Service
-      name: service
-    path: patches/manager_service.yaml
-  - target:
-      kind: ClusterRole
-      name: manager-role
-    path: patches/manager_role.yaml
-  - target:
-      kind: Deployment
-      name: controller-manager
-    path: patches/manager_deployment_certs.yaml
-  - target:
-      kind: Deployment
-      name: controller-manager
-    path: patches/manager_deployment_mount_etc_containers.yaml
-  - target:
-      kind: Deployment
-      name: controller-manager
-    path: patches/manager_deployment_log_verbosity.yaml
-  - target:
-      kind: Deployment
-      name: controller-manager
-    path: patches/manager_deployment_node_selection.yaml
+components:
+  - patches

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/kustomization.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: manager_namespace_privileged.yaml
+  - path: manager_namespace_monitored.yaml
+  - path: manager_namespace_annotations.yaml
+  - target:
+      kind: Service
+      name: service
+    path: manager_service.yaml
+  - target:
+      kind: ClusterRole
+      name: manager-role
+    path: manager_role.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
+    path: manager_deployment_certs.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
+    path: manager_deployment_mount_etc_containers.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
+    path: manager_deployment_log_verbosity.yaml
+  - target:
+      kind: Deployment
+      name: controller-manager
+    path: manager_deployment_node_selection.yaml

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/trusted-ca/kustomization.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/trusted-ca/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- operator_controller_trusted_ca_configmap.yaml

--- a/openshift/operator-controller/kustomize/overlays/openshift/openshift-config/kustomization.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/openshift-config/kustomization.yaml
@@ -1,5 +1,6 @@
 # Adds namespace to all resources.
 namespace: openshift-config
+namePrefix: operator-controller-
 
 resources:
 - rbac/operator-controller_manager_role.yaml

--- a/openshift/operator-controller/manifests-experimental/00-namespace-openshift-operator-controller.yml
+++ b/openshift/operator-controller/manifests-experimental/00-namespace-openshift-operator-controller.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: management
+  labels:
+    app.kubernetes.io/part-of: olm
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+  name: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/01-customresourcedefinition-clusterextensions.olm.operatorframework.io.yml
+++ b/openshift/operator-controller/manifests-experimental/01-customresourcedefinition-clusterextensions.olm.operatorframework.io.yml
@@ -1,0 +1,571 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    olm.operatorframework.io/generator: experimental
+  name: clusterextensions.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterExtension
+    listKind: ClusterExtensionList
+    plural: clusterextensions
+    singular: clusterextension
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.install.bundle.name
+          name: Installed Bundle
+          type: string
+        - jsonPath: .status.install.bundle.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Installed')].status
+          name: Installed
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+          name: Progressing
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterExtension is the Schema for the clusterextensions API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec is an optional field that defines the desired state of the ClusterExtension.
+              properties:
+                install:
+                  description: |-
+                    install is an optional field used to configure the installation options
+                    for the ClusterExtension such as the pre-flight check configuration.
+                  properties:
+                    preflight:
+                      description: |-
+                        preflight is an optional field that can be used to configure the checks that are
+                        run before installation or upgrade of the content for the package specified in the packageName field.
+
+                        When specified, it replaces the default preflight configuration for install/upgrade actions.
+                        When not specified, the default configuration will be used.
+                      properties:
+                        crdUpgradeSafety:
+                          description: |-
+                            crdUpgradeSafety is used to configure the CRD Upgrade Safety pre-flight
+                            checks that run prior to upgrades of installed content.
+
+                            The CRD Upgrade Safety pre-flight check safeguards from unintended
+                            consequences of upgrading a CRD, such as data loss.
+                          properties:
+                            enforcement:
+                              description: |-
+                                enforcement is a required field, used to configure the state of the CRD Upgrade Safety pre-flight check.
+
+                                Allowed values are "None" or "Strict". The default value is "Strict".
+
+                                When set to "None", the CRD Upgrade Safety pre-flight check will be skipped
+                                when performing an upgrade operation. This should be used with caution as
+                                unintended consequences such as data loss can occur.
+
+                                When set to "Strict", the CRD Upgrade Safety pre-flight check will be run when
+                                performing an upgrade operation.
+                              enum:
+                                - None
+                                - Strict
+                              type: string
+                          required:
+                            - enforcement
+                          type: object
+                      required:
+                        - crdUpgradeSafety
+                      type: object
+                      x-kubernetes-validations:
+                        - message: at least one of [crdUpgradeSafety] are required when preflight is specified
+                          rule: has(self.crdUpgradeSafety)
+                  type: object
+                  x-kubernetes-validations:
+                    - message: at least one of [preflight] are required when install is specified
+                      rule: has(self.preflight)
+                namespace:
+                  description: |-
+                    namespace is a reference to a Kubernetes namespace.
+                    This is the namespace in which the provided ServiceAccount must exist.
+                    It also designates the default namespace where namespace-scoped resources
+                    for the extension are applied to the cluster.
+                    Some extensions may contain namespace-scoped resources to be applied in other namespaces.
+                    This namespace must exist.
+
+                    namespace is required, immutable, and follows the DNS label standard
+                    as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
+                    start and end with an alphanumeric character, and be no longer than 63 characters
+
+                    [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                  maxLength: 63
+                  type: string
+                  x-kubernetes-validations:
+                    - message: namespace is immutable
+                      rule: self == oldSelf
+                    - message: namespace must be a valid DNS1123 label
+                      rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+                serviceAccount:
+                  description: |-
+                    serviceAccount is a reference to a ServiceAccount used to perform all interactions
+                    with the cluster that are required to manage the extension.
+                    The ServiceAccount must be configured with the necessary permissions to perform these interactions.
+                    The ServiceAccount must exist in the namespace referenced in the spec.
+                    serviceAccount is required.
+                  properties:
+                    name:
+                      description: |-
+                        name is a required, immutable reference to the name of the ServiceAccount
+                        to be used for installation and management of the content for the package
+                        specified in the packageName field.
+
+                        This ServiceAccount must exist in the installNamespace.
+
+                        name follows the DNS subdomain standard as defined in [RFC 1123].
+                        It must contain only lowercase alphanumeric characters,
+                        hyphens (-) or periods (.), start and end with an alphanumeric character,
+                        and be no longer than 253 characters.
+
+                        Some examples of valid values are:
+                          - some-serviceaccount
+                          - 123-serviceaccount
+                          - 1-serviceaccount-2
+                          - someserviceaccount
+                          - some.serviceaccount
+
+                        Some examples of invalid values are:
+                          - -some-serviceaccount
+                          - some-serviceaccount-
+
+                        [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                      maxLength: 253
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name is immutable
+                          rule: self == oldSelf
+                        - message: name must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                  required:
+                    - name
+                  type: object
+                source:
+                  description: |-
+                    source is a required field which selects the installation source of content
+                    for this ClusterExtension. Selection is performed by setting the sourceType.
+
+                    Catalog is currently the only implemented sourceType, and setting the
+                    sourcetype to "Catalog" requires the catalog field to also be defined.
+
+                    Below is a minimal example of a source definition (in yaml):
+
+                    source:
+                      sourceType: Catalog
+                      catalog:
+                        packageName: example-package
+                  properties:
+                    catalog:
+                      description: |-
+                        catalog is used to configure how information is sourced from a catalog.
+                        This field is required when sourceType is "Catalog", and forbidden otherwise.
+                      properties:
+                        channels:
+                          description: |-
+                            channels is an optional reference to a set of channels belonging to
+                            the package specified in the packageName field.
+
+                            A "channel" is a package-author-defined stream of updates for an extension.
+
+                            Each channel in the list must follow the DNS subdomain standard
+                            as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric character,
+                            and be no longer than 253 characters. No more than 256 channels can be specified.
+
+                            When specified, it is used to constrain the set of installable bundles and
+                            the automated upgrade path. This constraint is an AND operation with the
+                            version field. For example:
+                              - Given channel is set to "foo"
+                              - Given version is set to ">=1.0.0, <1.5.0"
+                              - Only bundles that exist in channel "foo" AND satisfy the version range comparison will be considered installable
+                              - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
+
+                            When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
+
+                            Some examples of valid values are:
+                              - 1.1.x
+                              - alpha
+                              - stable
+                              - stable-v1
+                              - v1-stable
+                              - dev-preview
+                              - preview
+                              - community
+
+                            Some examples of invalid values are:
+                              - -some-channel
+                              - some-channel-
+                              - thisisareallylongchannelnamethatisgreaterthanthemaximumlength
+                              - original_40
+                              - --default-channel
+
+                            [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                          items:
+                            maxLength: 253
+                            type: string
+                            x-kubernetes-validations:
+                              - message: channels entries must be valid DNS1123 subdomains
+                                rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                          maxItems: 256
+                          type: array
+                        packageName:
+                          description: |-
+                            packageName is a reference to the name of the package to be installed
+                            and is used to filter the content from catalogs.
+
+                            packageName is required, immutable, and follows the DNS subdomain standard
+                            as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric character,
+                            and be no longer than 253 characters.
+
+                            Some examples of valid values are:
+                              - some-package
+                              - 123-package
+                              - 1-package-2
+                              - somepackage
+
+                            Some examples of invalid values are:
+                              - -some-package
+                              - some-package-
+                              - thisisareallylongpackagenamethatisgreaterthanthemaximumlength
+                              - some.package
+
+                            [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                          maxLength: 253
+                          type: string
+                          x-kubernetes-validations:
+                            - message: packageName is immutable
+                              rule: self == oldSelf
+                            - message: packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters
+                              rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                        selector:
+                          description: |-
+                            selector is an optional field that can be used
+                            to filter the set of ClusterCatalogs used in the bundle
+                            selection process.
+
+                            When unspecified, all ClusterCatalogs will be used in
+                            the bundle selection process.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        upgradeConstraintPolicy:
+                          default: CatalogProvided
+                          description: |-
+                            upgradeConstraintPolicy is an optional field that controls whether
+                            the upgrade path(s) defined in the catalog are enforced for the package
+                            referenced in the packageName field.
+
+                            Allowed values are: "CatalogProvided" or "SelfCertified", or omitted.
+
+                            When this field is set to "CatalogProvided", automatic upgrades will only occur
+                            when upgrade constraints specified by the package author are met.
+
+                            When this field is set to "SelfCertified", the upgrade constraints specified by
+                            the package author are ignored. This allows for upgrades and downgrades to
+                            any version of the package. This is considered a dangerous operation as it
+                            can lead to unknown and potentially disastrous outcomes, such as data
+                            loss. It is assumed that users have independently verified changes when
+                            using this option.
+
+                            When this field is omitted, the default value is "CatalogProvided".
+                          enum:
+                            - CatalogProvided
+                            - SelfCertified
+                          type: string
+                        version:
+                          description: |-
+                            version is an optional semver constraint (a specific version or range of versions). When unspecified, the latest version available will be installed.
+
+                            Acceptable version ranges are no longer than 64 characters.
+                            Version ranges are composed of comma- or space-delimited values and one or
+                            more comparison operators, known as comparison strings. Additional
+                            comparison strings can be added using the OR operator (||).
+
+                            # Range Comparisons
+
+                            To specify a version range, you can use a comparison string like ">=3.0,
+                            <3.6". When specifying a range, automatic updates will occur within that
+                            range. The example comparison string means "install any version greater than
+                            or equal to 3.0.0 but less than 3.6.0.". It also states intent that if any
+                            upgrades are available within the version range after initial installation,
+                            those upgrades should be automatically performed.
+
+                            # Pinned Versions
+
+                            To specify an exact version to install you can use a version range that
+                            "pins" to a specific version. When pinning to a specific version, no
+                            automatic updates will occur. An example of a pinned version range is
+                            "0.6.0", which means "only install version 0.6.0 and never
+                            upgrade from this version".
+
+                            # Basic Comparison Operators
+
+                            The basic comparison operators and their meanings are:
+                              - "=", equal (not aliased to an operator)
+                              - "!=", not equal
+                              - "<", less than
+                              - ">", greater than
+                              - ">=", greater than OR equal to
+                              - "<=", less than OR equal to
+
+                            # Wildcard Comparisons
+
+                            You can use the "x", "X", and "*" characters as wildcard characters in all
+                            comparison operations. Some examples of using the wildcard characters:
+                              - "1.2.x", "1.2.X", and "1.2.*" is equivalent to ">=1.2.0, < 1.3.0"
+                              - ">= 1.2.x", ">= 1.2.X", and ">= 1.2.*" is equivalent to ">= 1.2.0"
+                              - "<= 2.x", "<= 2.X", and "<= 2.*" is equivalent to "< 3"
+                              - "x", "X", and "*" is equivalent to ">= 0.0.0"
+
+                            # Patch Release Comparisons
+
+                            When you want to specify a minor version up to the next major version you
+                            can use the "~" character to perform patch comparisons. Some examples:
+                              - "~1.2.3" is equivalent to ">=1.2.3, <1.3.0"
+                              - "~1" and "~1.x" is equivalent to ">=1, <2"
+                              - "~2.3" is equivalent to ">=2.3, <2.4"
+                              - "~1.2.x" is equivalent to ">=1.2.0, <1.3.0"
+
+                            # Major Release Comparisons
+
+                            You can use the "^" character to make major release comparisons after a
+                            stable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:
+                              - "^1.2.3" is equivalent to ">=1.2.3, <2.0.0"
+                              - "^1.2.x" is equivalent to ">=1.2.0, <2.0.0"
+                              - "^2.3" is equivalent to ">=2.3, <3"
+                              - "^2.x" is equivalent to ">=2.0.0, <3"
+                              - "^0.2.3" is equivalent to ">=0.2.3, <0.3.0"
+                              - "^0.2" is equivalent to ">=0.2.0, <0.3.0"
+                              - "^0.0.3" is equvalent to ">=0.0.3, <0.0.4"
+                              - "^0.0" is equivalent to ">=0.0.0, <0.1.0"
+                              - "^0" is equivalent to ">=0.0.0, <1.0.0"
+
+                            # OR Comparisons
+                            You can use the "||" character to represent an OR operation in the version
+                            range. Some examples:
+                              - ">=1.2.3, <2.0.0 || >3.0.0"
+                              - "^0 || ^3 || ^5"
+
+                            For more information on semver, please see https://semver.org/
+                          maxLength: 64
+                          type: string
+                          x-kubernetes-validations:
+                            - message: invalid version expression
+                              rule: self.matches("^(\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|[x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*]))?(\\.(0|[1-9]\\d*|x|X|\\*))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)((?:\\s+|,\\s*|\\s*\\|\\|\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*))?(\\.(0|[1-9]\\d*|x|X|\\*]))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)*$")
+                      required:
+                        - packageName
+                      type: object
+                    sourceType:
+                      description: |-
+                        sourceType is a required reference to the type of install source.
+
+                        Allowed values are "Catalog"
+
+                        When this field is set to "Catalog", information for determining the
+                        appropriate bundle of content to install will be fetched from
+                        ClusterCatalog resources existing on the cluster.
+                        When using the Catalog sourceType, the catalog field must also be set.
+                      enum:
+                        - Catalog
+                      type: string
+                  required:
+                    - sourceType
+                  type: object
+                  x-kubernetes-validations:
+                    - message: catalog is required when sourceType is Catalog, and forbidden otherwise
+                      rule: 'has(self.sourceType) && self.sourceType == ''Catalog'' ? has(self.catalog) : !has(self.catalog)'
+              required:
+                - namespace
+                - serviceAccount
+                - source
+              type: object
+            status:
+              description: status is an optional field that defines the observed state of the ClusterExtension.
+              properties:
+                conditions:
+                  description: |-
+                    The set of condition types which apply to all spec.source variations are Installed and Progressing.
+
+                    The Installed condition represents whether or not the bundle has been installed for this ClusterExtension.
+                    When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.
+                    When Installed is False and the Reason is Failed, the bundle has failed to install.
+
+                    The Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.
+                    When Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.
+                    When Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
+                    When Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.
+
+                    When the ClusterExtension is sourced from a catalog, if may also communicate a deprecation condition.
+                    These are indications from a package owner to guide users away from a particular package, channel, or bundle.
+                    BundleDeprecated is set if the requested bundle version is marked deprecated in the catalog.
+                    ChannelDeprecated is set if the requested channel is marked deprecated in the catalog.
+                    PackageDeprecated is set if the requested package is marked deprecated in the catalog.
+                    Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                install:
+                  description: install is a representation of the current installation status for this ClusterExtension.
+                  properties:
+                    bundle:
+                      description: |-
+                        bundle is a required field which represents the identifying attributes of a bundle.
+
+                        A "bundle" is a versioned set of content that represents the resources that
+                        need to be applied to a cluster to install a package.
+                      properties:
+                        name:
+                          description: |-
+                            name is required and follows the DNS subdomain standard
+                            as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric character,
+                            and be no longer than 253 characters.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters
+                              rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                        version:
+                          description: |-
+                            version is a required field and is a reference to the version that this bundle represents
+                            version follows the semantic versioning standard as defined in https://semver.org/.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: version must be well-formed semver
+                              rule: self.matches("^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*))?(\\+([-0-9A-Za-z]+(-\\.[-0-9A-Za-z]+)*))?")
+                      required:
+                        - name
+                        - version
+                      type: object
+                  required:
+                    - bundle
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/openshift/operator-controller/manifests-experimental/02-serviceaccount-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests-experimental/02-serviceaccount-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: operator-controller-controller-manager
+  namespace: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/03-role-openshift-config-operator-controller-manager-role.yml
+++ b/openshift/operator-controller/manifests-experimental/03-role-openshift-config-operator-controller-manager-role.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: operator-controller-manager-role
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/operator-controller/manifests-experimental/04-role-openshift-operator-controller-operator-controller-leader-election-role.yml
+++ b/openshift/operator-controller/manifests-experimental/04-role-openshift-operator-controller-operator-controller-leader-election-role.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operator-controller-leader-election-role
+  namespace: openshift-operator-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/openshift/operator-controller/manifests-experimental/05-role-openshift-operator-controller-operator-controller-manager-role.yml
+++ b/openshift/operator-controller/manifests-experimental/05-role-openshift-operator-controller-operator-controller-manager-role.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operator-controller-manager-role
+  namespace: openshift-operator-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/operator-controller/manifests-experimental/06-role-openshift-operator-controller-operator-controller-metrics-monitor-role.yml
+++ b/openshift/operator-controller/manifests-experimental/06-role-openshift-operator-controller-operator-controller-metrics-monitor-role.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    control-plane: operator-controller-controller-manager
+  name: operator-controller-metrics-monitor-role
+  namespace: openshift-operator-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/operator-controller/manifests-experimental/07-clusterrole-operator-controller-clusterextension-editor-role.yml
+++ b/openshift/operator-controller/manifests-experimental/07-clusterrole-operator-controller-clusterextension-editor-role.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-controller-clusterextension-editor-role
+rules:
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clusterextensions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/openshift/operator-controller/manifests-experimental/08-clusterrole-operator-controller-clusterextension-viewer-role.yml
+++ b/openshift/operator-controller/manifests-experimental/08-clusterrole-operator-controller-clusterextension-viewer-role.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-controller-clusterextension-viewer-role
+rules:
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clusterextensions
+    verbs:
+      - get
+      - list
+      - watch

--- a/openshift/operator-controller/manifests-experimental/09-clusterrole-operator-controller-manager-role.yml
+++ b/openshift/operator-controller/manifests-experimental/09-clusterrole-operator-controller-manager-role.yml
@@ -1,0 +1,67 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-controller-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clustercatalogs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clusterextensions
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clusterextensions/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - olm.operatorframework.io
+    resources:
+      - clusterextensions/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/openshift/operator-controller/manifests-experimental/10-clusterrole-operator-controller-metrics-reader.yml
+++ b/openshift/operator-controller/manifests-experimental/10-clusterrole-operator-controller-metrics-reader.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-controller-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/openshift/operator-controller/manifests-experimental/11-clusterrole-operator-controller-proxy-role.yml
+++ b/openshift/operator-controller/manifests-experimental/11-clusterrole-operator-controller-proxy-role.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-controller-proxy-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/openshift/operator-controller/manifests-experimental/12-rolebinding-openshift-config-operator-controller-manager-rolebinding.yml
+++ b/openshift/operator-controller/manifests-experimental/12-rolebinding-openshift-config-operator-controller-manager-rolebinding.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  name: operator-controller-manager-rolebinding
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-controller-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: operator-controller-controller-manager
+    namespace: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/13-rolebinding-openshift-operator-controller-operator-controller-leader-election-rolebinding.yml
+++ b/openshift/operator-controller/manifests-experimental/13-rolebinding-openshift-operator-controller-operator-controller-leader-election-rolebinding.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operator-controller-leader-election-rolebinding
+  namespace: openshift-operator-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-controller-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: operator-controller-controller-manager
+    namespace: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/14-rolebinding-openshift-operator-controller-operator-controller-manager-rolebinding.yml
+++ b/openshift/operator-controller/manifests-experimental/14-rolebinding-openshift-operator-controller-operator-controller-manager-rolebinding.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operator-controller-manager-rolebinding
+  namespace: openshift-operator-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-controller-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: operator-controller-controller-manager
+    namespace: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/15-rolebinding-openshift-operator-controller-operator-controller-metrics-monitor-rolebinding.yml
+++ b/openshift/operator-controller/manifests-experimental/15-rolebinding-openshift-operator-controller-operator-controller-metrics-monitor-rolebinding.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    control-plane: operator-controller-controller-manager
+  name: operator-controller-metrics-monitor-rolebinding
+  namespace: openshift-operator-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operator-controller-metrics-monitor-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/openshift/operator-controller/manifests-experimental/16-clusterrolebinding-operator-controller-manager-rolebinding.yml
+++ b/openshift/operator-controller/manifests-experimental/16-clusterrolebinding-operator-controller-manager-rolebinding.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-controller-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-controller-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: operator-controller-controller-manager
+    namespace: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/17-clusterrolebinding-operator-controller-proxy-rolebinding.yml
+++ b/openshift/operator-controller/manifests-experimental/17-clusterrolebinding-operator-controller-proxy-rolebinding.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-controller-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-controller-proxy-role
+subjects:
+  - kind: ServiceAccount
+    name: operator-controller-controller-manager
+    namespace: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/18-configmap-openshift-operator-controller-operator-controller-trusted-ca-bundle.yml
+++ b/openshift/operator-controller/manifests-experimental/18-configmap-openshift-operator-controller-operator-controller-trusted-ca-bundle.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: operator-controller-trusted-ca-bundle
+  namespace: openshift-operator-controller

--- a/openshift/operator-controller/manifests-experimental/19-service-openshift-operator-controller-operator-controller-service.yml
+++ b/openshift/operator-controller/manifests-experimental/19-service-openshift-operator-controller-operator-controller-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: operator-controller-cert
+  labels:
+    control-plane: operator-controller-controller-manager
+  name: operator-controller-service
+  namespace: openshift-operator-controller
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: operator-controller-controller-manager

--- a/openshift/operator-controller/manifests-experimental/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests-experimental/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -1,0 +1,161 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubectl.kubernetes.io/default-logs-container: manager
+  labels:
+    control-plane: operator-controller-controller-manager
+  name: operator-controller-controller-manager
+  namespace: openshift-operator-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
+      labels:
+        control-plane: operator-controller-controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - ppc64le
+                      - s390x
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --tls-cert=/var/certs/tls.crt
+            - --tls-key=/var/certs/tls.key
+            - --catalogd-cas-dir=/var/ca-certs
+            - --v=${LOG_VERBOSITY}
+            - --feature-gates=PreflightPermissions=true
+            - --feature-gates=SingleOwnNamespaceInstallSupport=true
+            - --feature-gates=WebhookProviderOpenshiftServiceCA=true
+            - --global-pull-secret=openshift-config/pull-secret
+          command:
+            - /operator-controller
+          env:
+            - name: SSL_CERT_DIR
+              value: /var/ca-certs
+          image: ${OPERATOR_CONTROLLER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /var/cache
+              name: cache
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/certs
+              name: operator-controller-certs
+            - mountPath: /var/ca-certs
+              name: ca-certs
+              readOnly: true
+            - mountPath: /etc/containers
+              name: etc-containers
+              readOnly: true
+            - mountPath: /etc/docker
+              name: etc-docker
+              readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        seLinuxOptions:
+          type: spc_t
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: operator-controller-controller-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120
+      volumes:
+        - emptyDir: {}
+          name: cache
+        - emptyDir: {}
+          name: tmp
+        - name: operator-controller-certs
+          secret:
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+            optional: false
+            secretName: operator-controller-cert
+        - name: ca-certs
+          projected:
+            sources:
+              - configMap:
+                  items:
+                    - key: ca-bundle.crt
+                      path: ca-bundle.crt
+                  name: operator-controller-trusted-ca-bundle
+                  optional: false
+              - configMap:
+                  items:
+                    - key: service-ca.crt
+                      path: service-ca.crt
+                  name: openshift-service-ca.crt
+                  optional: false
+        - hostPath:
+            path: /etc/containers
+            type: Directory
+          name: etc-containers
+        - hostPath:
+            path: /etc/docker
+            type: Directory
+          name: etc-docker
+      priorityClassName: system-cluster-critical

--- a/openshift/operator-controller/manifests-experimental/21-servicemonitor-openshift-operator-controller-operator-controller-metrics-monitor.yml
+++ b/openshift/operator-controller/manifests-experimental/21-servicemonitor-openshift-operator-controller-operator-controller-metrics-monitor.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: operator-controller-controller-manager
+    openshift.io/cluster-monitoring: "true"
+  name: operator-controller-metrics-monitor
+  namespace: openshift-operator-controller
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      path: /metrics
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: operator-controller-service.openshift-operator-controller.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-operator-controller
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager

--- a/openshift/operator-controller/manifests-experimental/22-networkpolicy-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests-experimental/22-networkpolicy-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-controller-controller-manager
+  namespace: openshift-operator-controller
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress

--- a/openshift/operator-controller/manifests-experimental/23-networkpolicy-openshift-operator-controller-operator-controller-default-deny-all-traffic.yml
+++ b/openshift/operator-controller/manifests-experimental/23-networkpolicy-openshift-operator-controller-operator-controller-default-deny-all-traffic.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-controller-default-deny-all-traffic
+  namespace: openshift-operator-controller
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress


### PR DESCRIPTION
Update the openshift kustomize configuration for both operator-controller and catalogd.

Update the manifest generation scripts to put the core generation code into a function (ignore-whitespace will help with the review), so that it can be called twice; once for standard, and once for experimental.

Move around some of the kustomization directives to
* Create a patch kustomization (Component) file and move the patch directives from olmv1-ns there. This allows it to be referenced from a different directory.
* Add a kustomization file for tusted-ca. This allows it to be referenced from a different directory.
* Move the setting of the namePrefix for operator-controller; this makes the generation compatible with upstream feature components.
* Define experimental kustomization files that reference existing components.
* Reference the correct CRDs (standard or experimental).
* Add references to upstream feature components into the experimental manifests.

This *will* add `--feature-gates` options from the upstream feature components to the experimental manifests. The cluster-olm-operator will strip those arguments from the deployments before adding the enabled feature gates.

Update the Dockerfiles to include the experimental manifests and a copy script (`cp-manifests`) into the image containers. The complexity of having multiple sets of manifests mean that the simple initContainer copy mechanism found in cluster-olm-operator is no longer sufficient.

This attempts to keep backwards compatibility with older versions of cluster-olm-operator, specifically by keeping the original (standard) manifests in the original location, and adding the experimental manifests in a new directory. The new `cp-manifests` script is used by newer versions of cluster-olm-operator.

The manifests are generated in a separate <drop> commit (which will get regenerated upon the bumper), this should help with the review.