### PR TITLE
OPRUN-3963: UPSTREAM: <carry>: [OTE] - chore: follow up #383 – fix make verify 

### DIFF
--- a/openshift/tests-extension/Makefile
+++ b/openshift/tests-extension/Makefile
@@ -38,7 +38,7 @@ TOOLS_BIN_DIR := $(CURDIR)/bin
 
 #SECTION Development
 .PHONY: verify #HELP To verify the code
-verify: tidy fmt vet lint check-metadata
+verify: tidy fmt vet lint
 
 .PHONY: tidy #HELP Run go mod tidy.
 tidy:


### PR DESCRIPTION
Follow up of: #383
We missed a `check-metadata` which was added in the review, and we convey that we cannot do this check so far, and I missed the cleanup before getting merged

```
~/go/src/github/operator-framework-operator-controller/openshift/tests-extension (fix-remove-target) $ make verify
go mod tidy
go fmt ./...
go vet ./...
/Users/camilam/go/bin/golangci-lint-v2.1.6 run
0 issues.
```

NOTE: After this fix, we can enable it in the CI and avoid errors: https://github.com/openshift/release/pull/66931
