### PR TITLE
NO-ISSUE: Remove build of test image registry

### DIFF
--- a/openshift/operator-controller/build-test-registry.sh
+++ b/openshift/operator-controller/build-test-registry.sh
@@ -51,12 +51,8 @@ spec:
     spec:
       containers:
       - name: registry
-        image: ${image}
+        image: registry:3
         imagePullPolicy: IfNotPresent
-        command:
-        - /registry
-        args:
-        - "--registry-address=:5000"
         volumeMounts:
         - mountPath: /var/certs
           name: operator-controller-e2e-certs

--- a/openshift/registry.Dockerfile
+++ b/openshift/registry.Dockerfile
@@ -3,12 +3,10 @@ WORKDIR /build
 COPY . .
 # TODO Modify upstream Makefile to separate the 'go build' commands
 # from 'image-registry' target so we don't need these
-RUN go build -o ./registry ./testdata/registry/registry.go
 RUN go build -o ./push     ./testdata/push/push.go
 
 FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 USER 1001
-COPY --from=builder /build/registry /registry
 COPY --from=builder /build/push /push
 COPY openshift/operator-controller/manifests /openshift/manifests
 COPY testdata/images /images


### PR DESCRIPTION
Upstream now uses a different image