### PR TITLE
OPRUN-3971: Add test-experimental-e2e target to openshift Makefile

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -30,6 +30,7 @@ export REG_PKG_NAME := registry-operator
 export E2E_TEST_CATALOG_V1 := e2e/test-catalog:v1
 export E2E_TEST_CATALOG_V2 := e2e/test-catalog:v2
 export CATALOG_IMG := $(LOCAL_REGISTRY_HOST)/$(E2E_TEST_CATALOG_V1)
+
 # Order matters here, the ".../registries.conf" entry must be last.
 export DOWNSTREAM_E2E_FLAGS := -count=1 -v -skip 'TestClusterExtensionInstallReResolvesWhenNewCatalog|TestClusterExtensionInstallRegistryDynamic|TestClusterExtensionInstallRegistry/package_requires_mirror_registry_configuration_in_/etc/containers/registries.conf'
 .PHONY: test-e2e
@@ -37,3 +38,10 @@ test-e2e: ## Run the e2e tests.
 	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_IMAGE)
 	cd $(DIR)/../; \
 	go test $(DOWNSTREAM_E2E_FLAGS) ./test/e2e/...;
+
+export DOWNSTREAM_EXPERIMENTAL_E2E_FLAGS := -count=1 -v
+.PHONY: test-experimental-e2e
+test-experimental-e2e: ## Run the experimental e2e tests.
+	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_IMAGE)
+	cd $(DIR)/../; \
+	go test $(DOWNSTREAM_EXPERIMENTAL_E2E_FLAGS) ./test/experimental-e2e/...;


### PR DESCRIPTION
This adds a test-experimental-e2e target to allow the CI to run the experimental e2e test.

This is a first step before updating openshift/release