### PR TITLE
NO-ISSUE: Fix experimental manifest copying

### DIFF
--- a/openshift/catalogd/cp-manifests
+++ b/openshift/catalogd/cp-manifests
@@ -14,6 +14,6 @@ fi
 
 if [ -d /openshift/manifests-experimental ]; then
     mkdir -p "${DEST}/experimental/catalogd"
-    cp -a /openshift/manifests "${DEST}/experimental/catalogd"
+    cp -a /openshift/manifests-experimental "${DEST}/experimental/catalogd"
 fi
 

--- a/openshift/operator-controller/cp-manifests
+++ b/openshift/operator-controller/cp-manifests
@@ -14,6 +14,6 @@ fi
 
 if [ -d /openshift/manifests-experimental ]; then
     mkdir -p "${DEST}/experimental/operator-controller"
-    cp -a /openshift/manifests "${DEST}/experimental/operator-controller"
+    cp -a /openshift/manifests-experimental "${DEST}/experimental/operator-controller"
 fi
 


### PR DESCRIPTION
The standard manifest was being copied rather than the experimental manifest. This meant that the expected feature-flags are not present. This is failing now that we are doing a check for those feature-flags.