### PR TITLE
OPRUN-4070: [OTE] add webhook tests

### DIFF
--- a/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
+++ b/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
@@ -48,5 +48,55 @@
     "source": "openshift:payload:olmv1",
     "lifecycle": "blocking",
     "environmentSelector": {}
+  },
+  {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working validating webhook",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  },
+  {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working mutating webhook",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  },
+  {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working conversion webhook",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  },
+  {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate rotation",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  },
+  {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
   }
 ]

--- a/openshift/tests-extension/pkg/helpers/catalogs.go
+++ b/openshift/tests-extension/pkg/helpers/catalogs.go
@@ -1,0 +1,52 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	//nolint:staticcheck // ST1001: dot-imports for readability
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	olmv1 "github.com/operator-framework/operator-controller/api/v1"
+
+	"github/operator-framework-operator-controller/openshift/tests-extension/pkg/env"
+)
+
+// NewClusterCatalog returns a new ClusterCatalog object.
+// It sets the image reference as source.
+func NewClusterCatalog(name, imageRef string) *olmv1.ClusterCatalog {
+	return &olmv1.ClusterCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: olmv1.ClusterCatalogSpec{
+			Source: olmv1.CatalogSource{
+				Type: olmv1.SourceTypeImage,
+				Image: &olmv1.ImageSource{
+					Ref: imageRef,
+				},
+			},
+		},
+	}
+}
+
+// ExpectCatalogToBeServing checks that the catalog with the given name is installed
+func ExpectCatalogToBeServing(ctx context.Context, name string) {
+	k8sClient := env.Get().K8sClient
+	Eventually(func(g Gomega) {
+		var catalog olmv1.ClusterCatalog
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, &catalog)
+		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get catalog %q", name))
+
+		conditions := catalog.Status.Conditions
+		g.Expect(conditions).NotTo(BeEmpty(), fmt.Sprintf("catalog %q has empty status.conditions", name))
+
+		g.Expect(meta.IsStatusConditionPresentAndEqual(conditions, olmv1.TypeServing, metav1.ConditionTrue)).
+			To(BeTrue(), fmt.Sprintf("catalog %q is not serving", name))
+	}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+}

--- a/openshift/tests-extension/test/webhooks.go
+++ b/openshift/tests-extension/test/webhooks.go
@@ -1,0 +1,362 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	//nolint:staticcheck // ST1001: dot-imports for readability
+	. "github.com/onsi/ginkgo/v2"
+	//nolint:staticcheck // ST1001: dot-imports for readability
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	olmv1 "github.com/operator-framework/operator-controller/api/v1"
+
+	"github/operator-framework-operator-controller/openshift/tests-extension/pkg/env"
+	"github/operator-framework-operator-controller/openshift/tests-extension/pkg/helpers"
+)
+
+const (
+	openshiftServiceCANamespace            = "openshift-service-ca"
+	openshiftServiceCASigningKeySecretName = "signing-key"
+
+	webhookCatalogName         = "webhook-operator-catalog"
+	webhookOperatorPackageName = "webhook-operator"
+	webhookOperatorCRDName     = "webhooktests.webhook.operators.coreos.io"
+)
+
+var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks",
+	Ordered, Serial, func() {
+		var (
+			k8sClient                       client.Client
+			dynamicClient                   dynamic.Interface
+			webhookOperatorInstallNamespace string
+			cleanup                         func(ctx context.Context)
+		)
+
+		BeforeEach(func(ctx SpecContext) {
+			By("initializing Kubernetes client and dynamic client")
+			k8sClient = env.Get().K8sClient
+			restCfg := env.Get().RestCfg
+			var err error
+			dynamicClient, err = dynamic.NewForConfig(restCfg)
+			Expect(err).ToNot(HaveOccurred(), "failed to create dynamic client")
+
+			By("requiring OLMv1 capability on OpenShift")
+			helpers.RequireOLMv1CapabilityOnOpenshift()
+
+			By("ensuring no ClusterExtension and CRD from a previous run")
+			helpers.EnsureCleanupClusterExtension(ctx, webhookOperatorPackageName, webhookOperatorCRDName)
+
+			By(fmt.Sprintf("checking if the %s exists", webhookCatalogName))
+			catalog := &olmv1.ClusterCatalog{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: webhookCatalogName}, catalog)
+			if apierrors.IsNotFound(err) {
+				By(fmt.Sprintf("creating the webhook-operator catalog with name %s", webhookCatalogName))
+				catalog = helpers.NewClusterCatalog(webhookCatalogName, "quay.io/operator-framework/webhook-operator-index:0.0.3")
+				err = k8sClient.Create(ctx, catalog)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("waiting for the webhook-operator catalog to be serving")
+				helpers.ExpectCatalogToBeServing(ctx, webhookCatalogName)
+			} else {
+				By(fmt.Sprintf("webhook-operator catalog %s already exists, skipping creation", webhookCatalogName))
+			}
+			webhookOperatorInstallNamespace = fmt.Sprintf("webhook-operator-%s", rand.String(5))
+			cleanup = setupWebhookOperator(ctx, k8sClient, webhookOperatorInstallNamespace)
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			By("performing webhook operator cleanup")
+			if cleanup != nil {
+				cleanup(ctx)
+			}
+		})
+
+		It("should have a working validating webhook", func(ctx SpecContext) {
+			By("creating a webhook test resource that will be rejected by the validating webhook")
+			Eventually(func() error {
+				name := fmt.Sprintf("validating-webhook-test-%s", rand.String(5))
+				obj := newWebhookTestV1(name, webhookOperatorInstallNamespace, false)
+
+				_, err := dynamicClient.
+					Resource(webhookTestGVRV1).
+					Namespace(webhookOperatorInstallNamespace).
+					Create(ctx, obj, metav1.CreateOptions{})
+
+				switch {
+				case err == nil:
+					// Webhook not ready yet; clean up and keep polling.
+					_ = dynamicClient.Resource(webhookTestGVRV1).
+						Namespace(webhookOperatorInstallNamespace).
+						Delete(ctx, name, metav1.DeleteOptions{})
+					return fmt.Errorf("webhook not rejecting yet")
+				case strings.Contains(err.Error(), "Invalid value: false: Spec.Valid must be true"):
+					return nil // got the expected validating-webhook rejection
+				default:
+					return fmt.Errorf("unexpected error: %v", err)
+				}
+			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+		})
+
+		It("should have a working mutating webhook", func(ctx SpecContext) {
+			By("creating a valid webhook test resource")
+			mutatingWebhookResourceName := "mutating-webhook-test"
+			resource := newWebhookTestV1(mutatingWebhookResourceName, webhookOperatorInstallNamespace, true)
+			Eventually(func(g Gomega) {
+				_, err := dynamicClient.Resource(webhookTestGVRV1).Namespace(webhookOperatorInstallNamespace).Create(ctx, resource, metav1.CreateOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+			By("getting the created resource in v1 schema")
+			obj, err := dynamicClient.Resource(webhookTestGVRV1).Namespace(webhookOperatorInstallNamespace).Get(ctx, mutatingWebhookResourceName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obj).ToNot(BeNil())
+
+			By("validating the resource spec")
+			spec := obj.Object["spec"].(map[string]interface{})
+			Expect(spec).To(Equal(map[string]interface{}{
+				"valid":  true,
+				"mutate": true,
+			}))
+		})
+
+		It("should have a working conversion webhook", func(ctx SpecContext) {
+			By("creating a conversion webhook test resource")
+			conversionWebhookResourceName := "conversion-webhook-test"
+			resourceV1 := newWebhookTestV1(conversionWebhookResourceName, webhookOperatorInstallNamespace, true)
+			Eventually(func(g Gomega) {
+				_, err := dynamicClient.Resource(webhookTestGVRV1).Namespace(webhookOperatorInstallNamespace).Create(ctx, resourceV1, metav1.CreateOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+			By("getting the created resource in v2 schema")
+			obj, err := dynamicClient.Resource(webhookTestGVRV2).Namespace(webhookOperatorInstallNamespace).Get(ctx, conversionWebhookResourceName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(obj).ToNot(BeNil())
+
+			By("validating the resource spec")
+			spec := obj.Object["spec"].(map[string]interface{})
+			Expect(spec).To(Equal(map[string]interface{}{
+				"conversion": map[string]interface{}{
+					"valid":  true,
+					"mutate": true,
+				},
+			}))
+		})
+
+		It("should be tolerant to openshift-service-ca certificate rotation", func(ctx SpecContext) {
+			By("deleting the openshift-service-ca signing-key secret")
+			signingKeySecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      openshiftServiceCASigningKeySecretName,
+					Namespace: openshiftServiceCANamespace,
+				},
+			}
+			err := k8sClient.Delete(ctx, signingKeySecret, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+			By("waiting for the webhook operator's service certificate secret to be recreated and populated")
+			certificateSecretName := "webhook-operator-webhook-service-cert"
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: certificateSecretName, Namespace: webhookOperatorInstallNamespace}, secret)
+				if apierrors.IsNotFound(err) {
+					GinkgoLogr.Info(fmt.Sprintf("Secret %s/%s not found yet (still polling for recreation)", webhookOperatorInstallNamespace, certificateSecretName))
+					return
+				}
+
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service certificate secret %s/%s: %v", webhookOperatorInstallNamespace, certificateSecretName, err))
+				g.Expect(secret.Data).ToNot(BeEmpty(), "expected webhook service certificate secret data to not be empty after recreation")
+			}).WithTimeout(2*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "webhook service certificate secret did not get recreated and populated within timeout")
+
+			By("checking webhook is responsive through cert rotation")
+			Eventually(func(g Gomega) {
+				resourceName := fmt.Sprintf("cert-rotation-test-%s", rand.String(5))
+				resource := newWebhookTestV1(resourceName, webhookOperatorInstallNamespace, true)
+
+				_, err := dynamicClient.Resource(webhookTestGVRV1).Namespace(webhookOperatorInstallNamespace).Create(ctx, resource, metav1.CreateOptions{})
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to create test resource %s: %v", resourceName, err))
+
+				err = dynamicClient.Resource(webhookTestGVRV1).Namespace(webhookOperatorInstallNamespace).Delete(ctx, resource.GetName(), metav1.DeleteOptions{})
+				g.Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred(), fmt.Sprintf("failed to delete test resource %s: %v", resourceName, err))
+			}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+		})
+
+		It("should be tolerant to tls secret deletion", func(ctx SpecContext) {
+			certificateSecretName := "webhook-operator-webhook-service-cert"
+			By("ensuring secret exists before deletion attempt")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: certificateSecretName, Namespace: webhookOperatorInstallNamespace}, secret)
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get secret %s/%s", webhookOperatorInstallNamespace, certificateSecretName))
+			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+			By("checking webhook is responsive through secret recreation after manual deletion")
+			tlsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      certificateSecretName,
+					Namespace: webhookOperatorInstallNamespace,
+				},
+			}
+			err := k8sClient.Delete(ctx, tlsSecret, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+			By("waiting for the webhook operator's service certificate secret to be recreated and populated")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: certificateSecretName, Namespace: webhookOperatorInstallNamespace}, secret)
+				if apierrors.IsNotFound(err) {
+					GinkgoLogr.Info(fmt.Sprintf("Secret %s/%s not found yet (still polling for recreation)", webhookOperatorInstallNamespace, certificateSecretName))
+					return
+				}
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service certificate secret %s/%s: %v", webhookOperatorInstallNamespace, certificateSecretName, err))
+				g.Expect(secret.Data).ToNot(BeEmpty(), "expected webhook service certificate secret data to not be empty after recreation")
+			}).WithTimeout(2*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "webhook service certificate secret did not get recreated and populated within timeout")
+
+			Eventually(func(g Gomega) {
+				resourceName := fmt.Sprintf("tls-deletion-test-%s", rand.String(5))
+				resource := newWebhookTestV1(resourceName, webhookOperatorInstallNamespace, true)
+
+				_, err := dynamicClient.Resource(webhookTestGVRV1).Namespace(webhookOperatorInstallNamespace).Create(ctx, resource, metav1.CreateOptions{})
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to create test resource %s: %v", resourceName, err))
+
+				err = dynamicClient.Resource(webhookTestGVRV1).Namespace(webhookOperatorInstallNamespace).Delete(ctx, resource.GetName(), metav1.DeleteOptions{})
+				g.Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred(), fmt.Sprintf("failed to delete test resource %s: %v", resourceName, err))
+			}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+		})
+	})
+
+var webhookTestGVRV1 = schema.GroupVersionResource{
+	Group:    "webhook.operators.coreos.io",
+	Version:  "v1",
+	Resource: "webhooktests",
+}
+
+var webhookTestGVRV2 = schema.GroupVersionResource{
+	Group:    "webhook.operators.coreos.io",
+	Version:  "v2",
+	Resource: "webhooktests",
+}
+
+func newWebhookTestV1(name, namespace string, valid bool) *unstructured.Unstructured {
+	mutateValue := valid
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "webhook.operators.coreos.io/v1",
+			"kind":       "WebhookTest",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"valid":  valid,
+				"mutate": mutateValue,
+			},
+		},
+	}
+	return obj
+}
+
+func setupWebhookOperator(ctx SpecContext, k8sClient client.Client, webhookOperatorInstallNamespace string) func(ctx context.Context) {
+	By(fmt.Sprintf("installing the webhook operator in namespace %s", webhookOperatorInstallNamespace))
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: webhookOperatorInstallNamespace},
+	}
+	err := k8sClient.Create(ctx, ns)
+	Expect(err).ToNot(HaveOccurred())
+
+	saName := fmt.Sprintf("%s-installer", webhookOperatorInstallNamespace)
+	sa := helpers.NewServiceAccount(saName, webhookOperatorInstallNamespace)
+	err = k8sClient.Create(ctx, sa)
+	Expect(err).ToNot(HaveOccurred())
+	helpers.ExpectServiceAccountExists(ctx, saName, webhookOperatorInstallNamespace)
+
+	By("creating a ClusterRoleBinding to cluster-admin for the webhook operator")
+	operatorClusterRoleBindingName := fmt.Sprintf("%s-operator-crb", webhookOperatorInstallNamespace)
+	operatorClusterRoleBinding := helpers.NewClusterRoleBinding(operatorClusterRoleBindingName, "cluster-admin", saName, webhookOperatorInstallNamespace)
+	err = k8sClient.Create(ctx, operatorClusterRoleBinding)
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to create ClusterRoleBinding %s",
+		operatorClusterRoleBindingName))
+	helpers.ExpectClusterRoleBindingExists(ctx, operatorClusterRoleBindingName)
+
+	ceName := webhookOperatorInstallNamespace
+	ce := helpers.NewClusterExtensionObject("webhook-operator", "0.0.1", ceName, saName, webhookOperatorInstallNamespace)
+	ce.Spec.Source.Catalog.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"olm.operatorframework.io/metadata.name": webhookCatalogName,
+		},
+	}
+	err = k8sClient.Create(ctx, ce)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("waiting for the webhook operator to be installed")
+	helpers.ExpectClusterExtensionToBeInstalled(ctx, ceName)
+
+	// Reordered checks: Service -> Secret -> Deployment
+	By("waiting for the webhook operator's service to be ready")
+	serviceName := "webhook-operator-webhook-service" // Standard name for the service created by the operator
+	Eventually(func(g Gomega) {
+		svc := &corev1.Service{}
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: serviceName, Namespace: webhookOperatorInstallNamespace}, svc)
+		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service %s/%s: %v", webhookOperatorInstallNamespace, serviceName, err))
+		g.Expect(svc.Spec.ClusterIP).ToNot(BeEmpty(), "expected webhook service to have a ClusterIP assigned")
+		g.Expect(svc.Spec.Ports).ToNot(BeEmpty(), "expected webhook service to have ports defined")
+	}).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "webhook service did not become ready within timeout")
+
+	By("waiting for the webhook operator's service certificate secret to exist and be populated")
+	certificateSecretName := "webhook-operator-webhook-service-cert" // Fixed to use the static name
+	Eventually(func(g Gomega) {
+		secret := &corev1.Secret{}
+		// Force bypassing the client cache for this Get operation
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: certificateSecretName, Namespace: webhookOperatorInstallNamespace}, secret) // Removed client.WithCacheDisabled
+
+		if apierrors.IsNotFound(err) {
+			GinkgoLogr.Info(fmt.Sprintf("Secret %s/%s not found yet (still polling)", webhookOperatorInstallNamespace, certificateSecretName))
+			return // Keep polling if not found
+		}
+
+		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service certificate secret %s/%s: %v",
+			webhookOperatorInstallNamespace, certificateSecretName, err))
+		g.Expect(secret.Data).ToNot(BeEmpty(), "expected webhook service certificate secret data to not be empty")
+	}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "webhook service certificate secret did not become available within timeout")
+
+	return func(ctx context.Context) {
+		By(fmt.Sprintf("cleanup: deleting ClusterExtension %s", ce.Name))
+		_ = k8sClient.Delete(ctx, ce, client.PropagationPolicy(metav1.DeletePropagationBackground))
+		By(fmt.Sprintf("cleanup: deleting ClusterRoleBinding %s", operatorClusterRoleBinding.Name))
+		_ = k8sClient.Delete(ctx, operatorClusterRoleBinding, client.PropagationPolicy(metav1.DeletePropagationBackground))
+		By(fmt.Sprintf("cleanup: deleting ServiceAccount %s in namespace %s", sa.Name, sa.Namespace))
+		_ = k8sClient.Delete(ctx, sa, client.PropagationPolicy(metav1.DeletePropagationBackground))
+		By(fmt.Sprintf("cleanup: deleting namespace %s", ns.Name))
+		_ = k8sClient.Delete(ctx, ns, client.PropagationPolicy(metav1.DeletePropagationForeground))
+
+		By(fmt.Sprintf("waiting for namespace %s to be fully deleted", webhookOperatorInstallNamespace))
+		pollErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(pollCtx context.Context) (bool, error) {
+			var currentNS corev1.Namespace
+			err := k8sClient.Get(pollCtx, client.ObjectKey{Name: webhookOperatorInstallNamespace}, &currentNS)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+			return false, nil
+		})
+		if pollErr != nil {
+			GinkgoLogr.Info(fmt.Sprintf("Warning: namespace %s deletion wait failed: %v", webhookOperatorInstallNamespace, pollErr))
+		}
+	}
+}


### PR DESCRIPTION
Migrates OLMv1 webhook operator tests from using external YAML files to defining resources in Go structs. This change removes file dependencies, improving test reliability and simplifying test setup.

The migration is a refactoring of code from https://github.com/openshift/origin/pull/30059. The new code uses better naming conventions and adapts the tests to work with a controller-runtime client, enhancing test consistency and maintainability.

The migration covers all core test scenarios:
- Validating, mutating, and conversion webhooks.
- Certificate and secret rotation tolerance.

**Local Test**

```sh
$ ./bin/olmv1-tests-ext run-suite olmv1/all
  [INFO] [env] Using kubeconfig: /Users/camilam/.kube/cluster-bot.kubeconfig[INFO] [env] Cluster environment initialized (OpenShift: true)  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/olmv1.go:147
    STEP: creating namespace install-test-ns-wq2l @ 08/11/25 16:48:09.394
    STEP: ensuring no ClusterExtension no ClusterExtension and CRD for cluster-logging @ 08/11/25 16:48:09.847
    STEP: applying the ClusterExtension resource @ 08/11/25 16:48:10.101
    STEP: ensuring ServiceAccount is available before proceeding @ 08/11/25 16:48:10.231
    STEP: ensuring ClusterRoleBinding is available before proceeding @ 08/11/25 16:48:10.485
    STEP: waiting for the cluster-logging ClusterExtension to be installed @ 08/11/25 16:48:10.742
    STEP: ensuring the cluster is not upgradeable when olm.maxopenshiftversion is specified @ 08/11/25 16:48:15.422
  • [6.820 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 6.821 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/webhooks.go:195
    STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:48:16.089
    STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:48:16.089
    STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:48:16.29
    STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:48:16.567
    STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:48:16.698
    STEP: installing the webhook operator in namespace webhook-operator-cxvmd @ 08/11/25 16:48:16.698
    STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:48:17.075
    STEP: waiting for the webhook operator to be installed @ 08/11/25 16:48:17.453
    STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:48:20.959
    STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:48:21.084
    STEP: ensuring secret exists before deletion attempt @ 08/11/25 16:48:21.215
    STEP: checking webhook is responsive through secret recreation after manual deletion @ 08/11/25 16:48:21.351
    STEP: waiting for the webhook operator's service certificate secret to be recreated and populated @ 08/11/25 16:48:21.482
  "level"=0 "msg"="Secret webhook-operator-cxvmd/webhook-operator-webhook-service-cert not found yet (still polling for recreation)"
    STEP: performing webhook operator cleanup @ 08/11/25 16:48:32.161
    STEP: cleanup: deleting ClusterExtension webhook-operator-cxvmd @ 08/11/25 16:48:32.161
    STEP: cleanup: deleting ClusterRoleBinding webhook-operator-cxvmd-operator-crb @ 08/11/25 16:48:32.301
    STEP: cleanup: deleting ServiceAccount webhook-operator-cxvmd-installer in namespace webhook-operator-cxvmd @ 08/11/25 16:48:32.455
    STEP: cleanup: deleting namespace webhook-operator-cxvmd @ 08/11/25 16:48:32.587
    STEP: waiting for namespace webhook-operator-cxvmd to be fully deleted @ 08/11/25 16:48:32.732
  • [26.765 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 26.765 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working mutating webhook
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/webhooks.go:111
    STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:48:42.855
    STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:48:42.855
    STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:48:42.978
    STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:48:43.221
    STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:48:43.343
    STEP: installing the webhook operator in namespace webhook-operator-b7z5f @ 08/11/25 16:48:43.344
    STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:48:43.714
    STEP: waiting for the webhook operator to be installed @ 08/11/25 16:48:44.156
    STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:48:47.657
    STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:48:47.778
    STEP: creating a valid webhook test resource @ 08/11/25 16:48:47.91
    STEP: getting the created resource in v1 schema @ 08/11/25 16:48:53.231
    STEP: validating the resource spec @ 08/11/25 16:48:53.351
    STEP: performing webhook operator cleanup @ 08/11/25 16:48:53.351
    STEP: cleanup: deleting ClusterExtension webhook-operator-b7z5f @ 08/11/25 16:48:53.352
    STEP: cleanup: deleting ClusterRoleBinding webhook-operator-b7z5f-operator-crb @ 08/11/25 16:48:53.489
    STEP: cleanup: deleting ServiceAccount webhook-operator-b7z5f-installer in namespace webhook-operator-b7z5f @ 08/11/25 16:48:53.621
    STEP: cleanup: deleting namespace webhook-operator-b7z5f @ 08/11/25 16:48:53.756
    STEP: waiting for namespace webhook-operator-b7z5f to be fully deleted @ 08/11/25 16:48:53.888
  • [21.162 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 21.162 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working validating webhook
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/webhooks.go:85
    STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:49:04.018
    STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:49:04.018
    STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:49:04.144
    STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:49:04.397
    STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:49:04.526
    STEP: installing the webhook operator in namespace webhook-operator-xwvfk @ 08/11/25 16:49:04.526
    STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:49:04.904
    STEP: waiting for the webhook operator to be installed @ 08/11/25 16:49:05.283
    STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:49:08.782
    STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:49:08.903
    STEP: creating a webhook test resource that will be rejected by the validating webhook @ 08/11/25 16:49:09.033
    STEP: performing webhook operator cleanup @ 08/11/25 16:49:14.426
    STEP: cleanup: deleting ClusterExtension webhook-operator-xwvfk @ 08/11/25 16:49:14.426
    STEP: cleanup: deleting ClusterRoleBinding webhook-operator-xwvfk-operator-crb @ 08/11/25 16:49:14.565
    STEP: cleanup: deleting ServiceAccount webhook-operator-xwvfk-installer in namespace webhook-operator-xwvfk @ 08/11/25 16:49:14.705
    STEP: cleanup: deleting namespace webhook-operator-xwvfk @ 08/11/25 16:49:14.843
    STEP: waiting for namespace webhook-operator-xwvfk to be fully deleted @ 08/11/25 16:49:14.978
  • [21.084 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 21.085 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should install a cluster extension
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/olmv1.go:97
    STEP: creating namespace install-test-ns-jgk5 @ 08/11/25 16:49:25.233
    STEP: ensuring no ClusterExtension and CRD for quay-operator @ 08/11/25 16:49:25.363
    STEP: applying the ClusterExtension resource @ 08/11/25 16:49:25.616
    STEP: ensuring ServiceAccount is available before proceeding @ 08/11/25 16:49:25.741
    STEP: ensuring ClusterRoleBinding is available before proceeding @ 08/11/25 16:49:25.994
    STEP: waiting for the quay-operator ClusterExtension to be installed @ 08/11/25 16:49:26.25
  • [5.235 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 5.235 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate rotation
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/webhooks.go:157
    STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:49:30.34
    STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:49:30.34
    STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:49:30.467
    STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:49:30.732
    STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:49:30.857
    STEP: installing the webhook operator in namespace webhook-operator-47bn9 @ 08/11/25 16:49:30.857
    STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:49:31.24
    STEP: waiting for the webhook operator to be installed @ 08/11/25 16:49:31.623
    STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:49:35.125
    STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:49:35.253
    STEP: deleting the openshift-service-ca signing-key secret @ 08/11/25 16:49:35.381
    STEP: waiting for the webhook operator's service certificate secret to be recreated and populated @ 08/11/25 16:49:35.521
    STEP: checking webhook is responsive through cert rotation @ 08/11/25 16:49:35.647
    STEP: performing webhook operator cleanup @ 08/11/25 16:51:07.24
    STEP: cleanup: deleting ClusterExtension webhook-operator-47bn9 @ 08/11/25 16:51:07.24
    STEP: cleanup: deleting ClusterRoleBinding webhook-operator-47bn9-operator-crb @ 08/11/25 16:51:07.383
    STEP: cleanup: deleting ServiceAccount webhook-operator-47bn9-installer in namespace webhook-operator-47bn9 @ 08/11/25 16:51:07.549
    STEP: cleanup: deleting namespace webhook-operator-47bn9 @ 08/11/25 16:51:07.698
    STEP: waiting for namespace webhook-operator-47bn9 to be fully deleted @ 08/11/25 16:51:07.837
  • [142.618 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 142.618 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should fail to install a non-existing cluster extension
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/olmv1.go:113
    STEP: creating namespace install-test-ns-rzt6 @ 08/11/25 16:51:53.088
    STEP: ensuring no ClusterExtension and CRD for non-existing operator @ 08/11/25 16:51:53.212
    STEP: applying the ClusterExtension resource @ 08/11/25 16:51:53.337
    STEP: ensuring ServiceAccount is available before proceeding @ 08/11/25 16:51:53.463
    STEP: ensuring ClusterRoleBinding is available before proceeding @ 08/11/25 16:51:53.714
    STEP: waiting for the ClusterExtension to exist @ 08/11/25 16:51:53.977
    STEP: waiting up to 2 minutes for ClusterExtension to report failure @ 08/11/25 16:51:54.113
  • [1.815 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 1.816 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1] OLMv1 should pass a trivial sanity check
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/olmv1.go:28
  • [0.000 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 0.000 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working conversion webhook
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/webhooks.go:133
    STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:51:54.777
    STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:51:54.777
    STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:51:54.902
    STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:51:55.153
    STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:51:55.285
    STEP: installing the webhook operator in namespace webhook-operator-p4lc8 @ 08/11/25 16:51:55.285
    STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:51:55.67
    STEP: waiting for the webhook operator to be installed @ 08/11/25 16:51:56.045
    STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:51:59.533
    STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:51:59.663
    STEP: creating a conversion webhook test resource @ 08/11/25 16:51:59.797
    STEP: getting the created resource in v2 schema @ 08/11/25 16:52:07.115
    STEP: validating the resource spec @ 08/11/25 16:52:07.25
    STEP: performing webhook operator cleanup @ 08/11/25 16:52:07.25
    STEP: cleanup: deleting ClusterExtension webhook-operator-p4lc8 @ 08/11/25 16:52:07.25
    STEP: cleanup: deleting ClusterRoleBinding webhook-operator-p4lc8-operator-crb @ 08/11/25 16:52:07.382
    STEP: cleanup: deleting ServiceAccount webhook-operator-p4lc8-installer in namespace webhook-operator-p4lc8 @ 08/11/25 16:52:07.625
    STEP: cleanup: deleting namespace webhook-operator-p4lc8 @ 08/11/25 16:52:07.752
    STEP: waiting for namespace webhook-operator-p4lc8 to be fully deleted @ 08/11/25 16:52:07.886
  • [23.233 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 23.233 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1754927288 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/olmv1.go:39
    STEP: verifying CRD clusterextensions.olm.operatorframework.io @ 08/11/25 16:52:18.139
    STEP: verifying CRD clustercatalogs.olm.operatorframework.io @ 08/11/25 16:52:18.278
  • [0.401 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 0.401 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed",
    "lifecycle": "blocking",
    "duration": 6821,
    "startTime": "2025-08-11 15:48:09.267266 UTC",
    "endTime": "2025-08-11 15:48:16.088457 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace install-test-ns-wq2l @ 08/11/25 16:48:09.394\n  STEP: ensuring no ClusterExtension no ClusterExtension and CRD for cluster-logging @ 08/11/25 16:48:09.847\n  STEP: applying the ClusterExtension resource @ 08/11/25 16:48:10.101\n  STEP: ensuring ServiceAccount is available before proceeding @ 08/11/25 16:48:10.231\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 08/11/25 16:48:10.485\n  STEP: waiting for the cluster-logging ClusterExtension to be installed @ 08/11/25 16:48:10.742\n  STEP: ensuring the cluster is not upgradeable when olm.maxopenshiftversion is specified @ 08/11/25 16:48:15.422\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion",
    "lifecycle": "blocking",
    "duration": 33587,
    "startTime": "2025-08-11 15:48:09.267264 UTC",
    "endTime": "2025-08-11 15:48:42.854719 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:48:16.089\n  STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:48:16.089\n  STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:48:16.29\n  STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:48:16.567\n  STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:48:16.698\n  STEP: installing the webhook operator in namespace webhook-operator-cxvmd @ 08/11/25 16:48:16.698\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:48:17.075\n  STEP: waiting for the webhook operator to be installed @ 08/11/25 16:48:17.453\n  STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:48:20.959\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:48:21.084\n  STEP: ensuring secret exists before deletion attempt @ 08/11/25 16:48:21.215\n  STEP: checking webhook is responsive through secret recreation after manual deletion @ 08/11/25 16:48:21.351\n  STEP: waiting for the webhook operator's service certificate secret to be recreated and populated @ 08/11/25 16:48:21.482\n  STEP: performing webhook operator cleanup @ 08/11/25 16:48:32.161\n  STEP: cleanup: deleting ClusterExtension webhook-operator-cxvmd @ 08/11/25 16:48:32.161\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-cxvmd-operator-crb @ 08/11/25 16:48:32.301\n  STEP: cleanup: deleting ServiceAccount webhook-operator-cxvmd-installer in namespace webhook-operator-cxvmd @ 08/11/25 16:48:32.455\n  STEP: cleanup: deleting namespace webhook-operator-cxvmd @ 08/11/25 16:48:32.587\n  STEP: waiting for namespace webhook-operator-cxvmd to be fully deleted @ 08/11/25 16:48:32.732\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working mutating webhook",
    "lifecycle": "blocking",
    "duration": 54750,
    "startTime": "2025-08-11 15:48:09.267282 UTC",
    "endTime": "2025-08-11 15:49:04.017501 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:48:42.855\n  STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:48:42.855\n  STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:48:42.978\n  STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:48:43.221\n  STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:48:43.343\n  STEP: installing the webhook operator in namespace webhook-operator-b7z5f @ 08/11/25 16:48:43.344\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:48:43.714\n  STEP: waiting for the webhook operator to be installed @ 08/11/25 16:48:44.156\n  STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:48:47.657\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:48:47.778\n  STEP: creating a valid webhook test resource @ 08/11/25 16:48:47.91\n  STEP: getting the created resource in v1 schema @ 08/11/25 16:48:53.231\n  STEP: validating the resource spec @ 08/11/25 16:48:53.351\n  STEP: performing webhook operator cleanup @ 08/11/25 16:48:53.351\n  STEP: cleanup: deleting ClusterExtension webhook-operator-b7z5f @ 08/11/25 16:48:53.352\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-b7z5f-operator-crb @ 08/11/25 16:48:53.489\n  STEP: cleanup: deleting ServiceAccount webhook-operator-b7z5f-installer in namespace webhook-operator-b7z5f @ 08/11/25 16:48:53.621\n  STEP: cleanup: deleting namespace webhook-operator-b7z5f @ 08/11/25 16:48:53.756\n  STEP: waiting for namespace webhook-operator-b7z5f to be fully deleted @ 08/11/25 16:48:53.888\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working validating webhook",
    "lifecycle": "blocking",
    "duration": 75835,
    "startTime": "2025-08-11 15:48:09.267287 UTC",
    "endTime": "2025-08-11 15:49:25.102773 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:49:04.018\n  STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:49:04.018\n  STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:49:04.144\n  STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:49:04.397\n  STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:49:04.526\n  STEP: installing the webhook operator in namespace webhook-operator-xwvfk @ 08/11/25 16:49:04.526\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:49:04.904\n  STEP: waiting for the webhook operator to be installed @ 08/11/25 16:49:05.283\n  STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:49:08.782\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:49:08.903\n  STEP: creating a webhook test resource that will be rejected by the validating webhook @ 08/11/25 16:49:09.033\n  STEP: performing webhook operator cleanup @ 08/11/25 16:49:14.426\n  STEP: cleanup: deleting ClusterExtension webhook-operator-xwvfk @ 08/11/25 16:49:14.426\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-xwvfk-operator-crb @ 08/11/25 16:49:14.565\n  STEP: cleanup: deleting ServiceAccount webhook-operator-xwvfk-installer in namespace webhook-operator-xwvfk @ 08/11/25 16:49:14.705\n  STEP: cleanup: deleting namespace webhook-operator-xwvfk @ 08/11/25 16:49:14.843\n  STEP: waiting for namespace webhook-operator-xwvfk to be fully deleted @ 08/11/25 16:49:14.978\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should install a cluster extension",
    "lifecycle": "blocking",
    "duration": 81071,
    "startTime": "2025-08-11 15:48:09.267290 UTC",
    "endTime": "2025-08-11 15:49:30.339028 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace install-test-ns-jgk5 @ 08/11/25 16:49:25.233\n  STEP: ensuring no ClusterExtension and CRD for quay-operator @ 08/11/25 16:49:25.363\n  STEP: applying the ClusterExtension resource @ 08/11/25 16:49:25.616\n  STEP: ensuring ServiceAccount is available before proceeding @ 08/11/25 16:49:25.741\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 08/11/25 16:49:25.994\n  STEP: waiting for the quay-operator ClusterExtension to be installed @ 08/11/25 16:49:26.25\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate rotation",
    "lifecycle": "blocking",
    "duration": 223692,
    "startTime": "2025-08-11 15:48:09.267303 UTC",
    "endTime": "2025-08-11 15:51:52.959333 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:49:30.34\n  STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:49:30.34\n  STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:49:30.467\n  STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:49:30.732\n  STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:49:30.857\n  STEP: installing the webhook operator in namespace webhook-operator-47bn9 @ 08/11/25 16:49:30.857\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:49:31.24\n  STEP: waiting for the webhook operator to be installed @ 08/11/25 16:49:31.623\n  STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:49:35.125\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:49:35.253\n  STEP: deleting the openshift-service-ca signing-key secret @ 08/11/25 16:49:35.381\n  STEP: waiting for the webhook operator's service certificate secret to be recreated and populated @ 08/11/25 16:49:35.521\n  STEP: checking webhook is responsive through cert rotation @ 08/11/25 16:49:35.647\n  STEP: performing webhook operator cleanup @ 08/11/25 16:51:07.24\n  STEP: cleanup: deleting ClusterExtension webhook-operator-47bn9 @ 08/11/25 16:51:07.24\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-47bn9-operator-crb @ 08/11/25 16:51:07.383\n  STEP: cleanup: deleting ServiceAccount webhook-operator-47bn9-installer in namespace webhook-operator-47bn9 @ 08/11/25 16:51:07.549\n  STEP: cleanup: deleting namespace webhook-operator-47bn9 @ 08/11/25 16:51:07.698\n  STEP: waiting for namespace webhook-operator-47bn9 to be fully deleted @ 08/11/25 16:51:07.837\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should fail to install a non-existing cluster extension",
    "lifecycle": "blocking",
    "duration": 225508,
    "startTime": "2025-08-11 15:48:09.267305 UTC",
    "endTime": "2025-08-11 15:51:54.776210 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace install-test-ns-rzt6 @ 08/11/25 16:51:53.088\n  STEP: ensuring no ClusterExtension and CRD for non-existing operator @ 08/11/25 16:51:53.212\n  STEP: applying the ClusterExtension resource @ 08/11/25 16:51:53.337\n  STEP: ensuring ServiceAccount is available before proceeding @ 08/11/25 16:51:53.463\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 08/11/25 16:51:53.714\n  STEP: waiting for the ClusterExtension to exist @ 08/11/25 16:51:53.977\n  STEP: waiting up to 2 minutes for ClusterExtension to report failure @ 08/11/25 16:51:54.113\n"
  },
  {
    "name": "[sig-olmv1] OLMv1 should pass a trivial sanity check",
    "lifecycle": "blocking",
    "duration": 225509,
    "startTime": "2025-08-11 15:48:09.267308 UTC",
    "endTime": "2025-08-11 15:51:54.777064 UTC",
    "result": "passed",
    "output": ""
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working conversion webhook",
    "lifecycle": "blocking",
    "duration": 248743,
    "startTime": "2025-08-11 15:48:09.267285 UTC",
    "endTime": "2025-08-11 15:52:18.010672 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client and dynamic client @ 08/11/25 16:51:54.777\n  STEP: requiring OLMv1 capability on OpenShift @ 08/11/25 16:51:54.777\n  STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/11/25 16:51:54.902\n  STEP: checking if the webhook-operator-catalog exists @ 08/11/25 16:51:55.153\n  STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/11/25 16:51:55.285\n  STEP: installing the webhook operator in namespace webhook-operator-p4lc8 @ 08/11/25 16:51:55.285\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/11/25 16:51:55.67\n  STEP: waiting for the webhook operator to be installed @ 08/11/25 16:51:56.045\n  STEP: waiting for the webhook operator's service to be ready @ 08/11/25 16:51:59.533\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/11/25 16:51:59.663\n  STEP: creating a conversion webhook test resource @ 08/11/25 16:51:59.797\n  STEP: getting the created resource in v2 schema @ 08/11/25 16:52:07.115\n  STEP: validating the resource spec @ 08/11/25 16:52:07.25\n  STEP: performing webhook operator cleanup @ 08/11/25 16:52:07.25\n  STEP: cleanup: deleting ClusterExtension webhook-operator-p4lc8 @ 08/11/25 16:52:07.25\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-p4lc8-operator-crb @ 08/11/25 16:52:07.382\n  STEP: cleanup: deleting ServiceAccount webhook-operator-p4lc8-installer in namespace webhook-operator-p4lc8 @ 08/11/25 16:52:07.625\n  STEP: cleanup: deleting namespace webhook-operator-p4lc8 @ 08/11/25 16:52:07.752\n  STEP: waiting for namespace webhook-operator-p4lc8 to be fully deleted @ 08/11/25 16:52:07.886\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed",
    "lifecycle": "blocking",
    "duration": 249145,
    "startTime": "2025-08-11 15:48:09.267274 UTC",
    "endTime": "2025-08-11 15:52:18.412487 UTC",
    "result": "passed",
    "output": "  STEP: verifying CRD clusterextensions.olm.operatorframework.io @ 08/11/25 16:52:18.139\n  STEP: verifying CRD clustercatalogs.olm.operatorframework.io @ 08/11/25 16:52:18.278\n"
  }
]
```


Assisted-by: Gemini