### PR TITLE
NO-ISSUE: [OTE] Refac: refac helper and olmv1 test to create namespace instead to use pre-existent

### DIFF
--- a/openshift/tests-extension/pkg/helpers/cluster_extension.go
+++ b/openshift/tests-extension/pkg/helpers/cluster_extension.go
@@ -2,25 +2,27 @@ package helpers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	olmv1 "github.com/operator-framework/operator-controller/api/v1"
 
 	"github/operator-framework-operator-controller/openshift/tests-extension/pkg/env"
 )
 
-const openshiftOperatorsNs = "openshift-operators"
-
 // CreateClusterExtension creates a ServiceAccount, ClusterRoleBinding, and ClusterExtension using typed APIs.
 // It returns the unique suffix and a cleanup function.
-func CreateClusterExtension(packageName, version string) (string, func()) {
+func CreateClusterExtension(packageName, version, namespace string) (string, func()) {
 	ctx := context.TODO()
 	k8sClient := env.Get().K8sClient
 	unique := rand.String(8)
@@ -30,53 +32,16 @@ func CreateClusterExtension(packageName, version string) (string, func()) {
 	ceName := "install-test-ce-" + unique
 
 	// 1. Create ServiceAccount
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: openshiftOperatorsNs,
-		},
-	}
-	Expect(k8sClient.Create(ctx, sa)).To(Succeed(), "failed to create ServiceAccount")
+	sa := NewServiceAccount(saName, namespace)
+	Expect(k8sClient.Create(ctx, sa)).To(Succeed(),
+		"failed to create ServiceAccount")
 
 	// 2. Create ClusterRoleBinding
-	crb := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: crbName,
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "cluster-admin",
-		},
-		Subjects: []rbacv1.Subject{{
-			Kind:      "ServiceAccount",
-			Name:      saName,
-			Namespace: openshiftOperatorsNs,
-		}},
-	}
+	crb := NewClusterRoleBinding(crbName, "cluster-admin", saName, namespace)
 	Expect(k8sClient.Create(ctx, crb)).To(Succeed(), "failed to create ClusterRoleBinding")
 
 	// 3. Create ClusterExtension
-	ce := &ocv1.ClusterExtension{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ceName,
-		},
-		Spec: ocv1.ClusterExtensionSpec{
-			Namespace: openshiftOperatorsNs,
-			ServiceAccount: ocv1.ServiceAccountReference{
-				Name: saName,
-			},
-			Source: ocv1.SourceConfig{
-				SourceType: ocv1.SourceTypeCatalog,
-				Catalog: &ocv1.CatalogFilter{
-					PackageName:             packageName,
-					Version:                 version,
-					Selector:                &metav1.LabelSelector{},
-					UpgradeConstraintPolicy: ocv1.UpgradeConstraintPolicyCatalogProvided,
-				},
-			},
-		},
-	}
+	ce := NewClusterExtensionObject(packageName, version, ceName, saName, namespace)
 	Expect(k8sClient.Create(ctx, ce)).To(Succeed(), "failed to create ClusterExtension")
 
 	// Cleanup closure
@@ -85,4 +50,74 @@ func CreateClusterExtension(packageName, version string) (string, func()) {
 		_ = k8sClient.Delete(ctx, crb)
 		_ = k8sClient.Delete(ctx, sa)
 	}
+}
+
+// NewServiceAccount creates a new ServiceAccount object in the openshift-operators namespace.
+func NewServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// NewClusterRoleBinding creates a new ClusterRoleBinding object that binds a ClusterRole to a ServiceAccount.
+func NewClusterRoleBinding(name, roleName, saName, namespace string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      saName,
+			Namespace: namespace,
+		}},
+	}
+}
+
+// NewClusterExtensionObject creates a new ClusterExtension object with the specified package, version, name, and ServiceAccount.
+func NewClusterExtensionObject(pkg, version, ceName, saName, namespace string) *olmv1.ClusterExtension {
+	return &olmv1.ClusterExtension{
+		ObjectMeta: metav1.ObjectMeta{Name: ceName},
+		Spec: olmv1.ClusterExtensionSpec{
+			Namespace: namespace,
+			ServiceAccount: olmv1.ServiceAccountReference{
+				Name: saName,
+			},
+			Source: olmv1.SourceConfig{
+				SourceType: olmv1.SourceTypeCatalog,
+				Catalog: &olmv1.CatalogFilter{
+					PackageName:             pkg,
+					Version:                 version,
+					Selector:                &metav1.LabelSelector{},
+					UpgradeConstraintPolicy: olmv1.UpgradeConstraintPolicyCatalogProvided,
+				},
+			},
+		},
+	}
+}
+
+// ExpectClusterExtensionToBeInstalled checks that the ClusterExtension has both Progressing=True and Installed=True.
+func ExpectClusterExtensionToBeInstalled(ctx context.Context, name string) {
+	k8sClient := env.Get().K8sClient
+	Eventually(func(g Gomega) {
+		var ext olmv1.ClusterExtension
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, &ext)
+		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get ClusterExtension %q", name))
+
+		conditions := ext.Status.Conditions
+		g.Expect(conditions).NotTo(BeEmpty(), fmt.Sprintf("ClusterExtension %q has empty status.conditions", name))
+
+		progressing := meta.FindStatusCondition(conditions, string(olmv1.TypeProgressing))
+		g.Expect(progressing).ToNot(BeNil(), "Progressing condition not found")
+		g.Expect(progressing.Status).To(Equal(metav1.ConditionTrue), "Progressing should be True")
+
+		installed := meta.FindStatusCondition(conditions, string(olmv1.TypeInstalled))
+		g.Expect(installed).ToNot(BeNil(), "Installed condition not found")
+		g.Expect(installed.Status).To(Equal(metav1.ConditionTrue), "Installed should be True")
+	}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
 }

--- a/openshift/tests-extension/test/olmv1.go
+++ b/openshift/tests-extension/test/olmv1.go
@@ -11,9 +11,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	olmv1 "github.com/operator-framework/operator-controller/api/v1"
@@ -71,37 +73,42 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs", func() {
 })
 
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation", func() {
+	var (
+		namespace string
+		k8sClient client.Client
+	)
 	BeforeEach(func() {
 		helpers.RequireOLMv1CapabilityOnOpenshift()
+		k8sClient = env.Get().K8sClient
+		namespace = "install-test-ns-" + rand.String(4)
+
+		By(fmt.Sprintf("creating namespace %s for single-namespace tests", namespace))
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), ns)).To(Succeed(), "failed to create test namespace")
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(context.Background(), ns)
+		})
 	})
+
 	It("should install a cluster extension", func(ctx SpecContext) {
 		if !env.Get().IsOpenShift {
 			Skip("Requires OCP Catalogs: not OpenShift")
 		}
 		By("applying the ClusterExtension resource")
-		name, cleanup := helpers.CreateClusterExtension("quay-operator", "3.13.0")
+		name, cleanup := helpers.CreateClusterExtension("quay-operator", "3.13.0", namespace)
 		DeferCleanup(cleanup)
 
 		By("waiting for the quay-operator ClusterExtension to be installed")
-		Eventually(func(g Gomega) {
-			k8sClient := env.Get().K8sClient
-			ce := &olmv1.ClusterExtension{}
-			err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, ce)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			progressing := meta.FindStatusCondition(ce.Status.Conditions, olmv1.TypeProgressing)
-			g.Expect(progressing).ToNot(BeNil())
-			g.Expect(progressing.Status).To(Equal(metav1.ConditionTrue))
-
-			installed := meta.FindStatusCondition(ce.Status.Conditions, olmv1.TypeInstalled)
-			g.Expect(installed).ToNot(BeNil())
-			g.Expect(installed.Status).To(Equal(metav1.ConditionTrue))
-		}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+		helpers.ExpectClusterExtensionToBeInstalled(ctx, name)
 	})
 
 	It("should fail to install a non-existing cluster extension", func(ctx SpecContext) {
 		By("applying the ClusterExtension resource")
-		name, cleanup := helpers.CreateClusterExtension("does-not-exist", "99.99.99")
+		name, cleanup := helpers.CreateClusterExtension("does-not-exist", "99.99.99", namespace)
 		DeferCleanup(cleanup)
 
 		By("waiting for the ClusterExtension to exist")
@@ -136,7 +143,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 		}
 
 		By("applying the ClusterExtension resource")
-		name, cleanup := helpers.CreateClusterExtension("cluster-logging", "6.2.2")
+		name, cleanup := helpers.CreateClusterExtension("cluster-logging", "6.2.2", namespace)
 		DeferCleanup(cleanup)
 
 		By("waiting for the function-mesh ClusterExtension to be installed")


### PR DESCRIPTION
The refactoring will be required for the other tests to use the helper
Also, it ensures that we create a namespace specific to the test instead of using a pre-existing one to ensure that tests are isolated.