### PR TITLE
OCPBUGS-60380: Backporting NetworkPolicy support for OLM bundles

### DIFF
--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -103,6 +103,16 @@ rules:
     - "bind"
     - "escalate"
   - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+  - apiGroups:
     - "olm.operatorframework.io"
     resources:
     - "clusterextensions/finalizers"

--- a/internal/operator-controller/rukpak/convert/registryv1.go
+++ b/internal/operator-controller/rukpak/convert/registryv1.go
@@ -402,6 +402,17 @@ func (c Converter) Convert(rv1 RegistryV1, installNamespace string, targetNamesp
 	for _, obj := range rv1.Others {
 		obj := obj
 		supported, namespaced := registrybundle.IsSupported(obj.GetKind())
+		// NOTE: This is a hack to backport "NetworkPolicy object kind in bundles" support from
+		// https://github.com/operator-framework/operator-registry/pull/1675
+		// The feature was introduced in OCP 4.20 with a operator-registry bump to v1.55.0.
+		// Ref:
+		// 1. operator-registry v1.55.0 release: https://github.com/operator-framework/operator-registry/releases/tag/v1.55.0
+		// 2. operator-registry bump in OCP 4.20: https://github.com/operator-framework/operator-controller/pull/1981
+		// Because the upstream PR is not being backported in operator-registry to older tags (with new z stream releases),
+		// this achieves a downstream-only backport for this feature.
+		if obj.GetKind() == "NetworkPolicy" {
+			supported, namespaced = true, true
+		}
 		if !supported {
 			return nil, fmt.Errorf("bundle contains unsupported resource: Name: %v, Kind: %v", obj.GetName(), obj.GetKind())
 		}

--- a/test/e2e/cluster_extension_install_test.go
+++ b/test/e2e/cluster_extension_install_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -152,6 +153,23 @@ func createClusterRoleAndBindingForSA(ctx context.Context, name string, sa *core
 					"watch",
 					"bind",
 					"escalate",
+				},
+			},
+			{
+				APIGroups: []string{
+					"networking.k8s.io",
+				},
+				Resources: []string{
+					"networkpolicies",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"update",
+					"patch",
+					"delete",
 				},
 			},
 		},
@@ -383,6 +401,11 @@ func TestClusterExtensionInstallRegistry(t *testing.T) {
 			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: ns.Name, Name: "test-configmap"}, &cm))
 			require.Contains(t, cm.Annotations, "shouldNotTemplate")
 			require.Contains(t, cm.Annotations["shouldNotTemplate"], "{{ $labels.namespace }}")
+			t.Log("By eventually creating the NetworkPolicy named 'test-operator-network-policy'")
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				var np networkingv1.NetworkPolicy
+				assert.NoError(ct, c.Get(context.Background(), types.NamespacedName{Name: "test-operator-network-policy", Namespace: ns.Name}, &np))
+			}, pollDuration, pollInterval)
 		})
 	}
 }

--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.clusterserviceversion.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.clusterserviceversion.yaml
@@ -97,6 +97,16 @@ spec:
           - patch
           - delete
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases

--- a/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.networkpolicy.yaml
+++ b/testdata/images/bundles/test-operator/v1.0.0/manifests/testoperator.networkpolicy.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-operator-network-policy
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
This is a hack to backport "NetworkPolicy object kind in bundles" support from https://github.com/operator-framework/operator-registry/pull/1675 The feature was introduced in OCP 4.20 with a operator-registry bump to v1.55.0. Ref:
1. operator-registry v1.55.0 release: https://github.com/operator-framework/operator-registry/releases/tag/v1.55.0
2. operator-registry bump in OCP 4.20: https://github.com/operator-framework/operator-controller/pull/1981 

Because the upstream PR is not being backported in operator-registry to older tags (with new z stream releases), this achieves a downstream-only backport for this feature.

We're backporting this support to prevent any breakage in case a bundle is included in a 4.19 catalog. 