### PR TITLE
NO-ISSUE: Handle service-ca cert availability/rotation

### DIFF
--- a/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/catalogd/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -17,8 +17,10 @@
   path: /spec/template/spec/containers/0/args/-
   value: "--tls-key=/var/certs/tls.key"
 - op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--pull-cas-dir=/var/ca-certs"
+- op: remove
   path: /spec/template/spec/containers/0/env
-  value: [{"name":"SSL_CERT_DIR", "value":"/var/ca-certs"}]
 - op: add
   path: /spec/template/spec/securityContext/seLinuxOptions
   value: {"type":"spc_t"}

--- a/openshift/catalogd/manifests-experimental/18-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests-experimental/18-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -46,14 +46,12 @@ spec:
             - --external-address=catalogd-service.openshift-catalogd.svc
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
+            - --pull-cas-dir=/var/ca-certs
             - --v=${LOG_VERBOSITY}
             - --feature-gates=APIV1MetasHandler=true
             - --global-pull-secret=openshift-config/pull-secret
           command:
             - ./catalogd
-          env:
-            - name: SSL_CERT_DIR
-              value: /var/ca-certs
           image: ${CATALOGD_IMAGE}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/catalogd/manifests/18-deployment-openshift-catalogd-catalogd-controller-manager.yml
+++ b/openshift/catalogd/manifests/18-deployment-openshift-catalogd-catalogd-controller-manager.yml
@@ -46,13 +46,11 @@ spec:
             - --external-address=catalogd-service.openshift-catalogd.svc
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
+            - --pull-cas-dir=/var/ca-certs
             - --v=${LOG_VERBOSITY}
             - --global-pull-secret=openshift-config/pull-secret
           command:
             - ./catalogd
-          env:
-            - name: SSL_CERT_DIR
-              value: /var/ca-certs
           image: ${CATALOGD_IMAGE}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
+++ b/openshift/operator-controller/kustomize/overlays/openshift/olmv1-ns/patches/manager_deployment_certs.yaml
@@ -20,8 +20,8 @@
   path: /spec/template/spec/containers/0/args/-
   value: "--catalogd-cas-dir=/var/ca-certs"
 - op: add
-  path: /spec/template/spec/containers/0/env
-  value: [{"name":"SSL_CERT_DIR", "value":"/var/ca-certs"}]
+  path: /spec/template/spec/containers/0/args/-
+  value: "--pull-cas-dir=/var/ca-certs"
 - op: add
   path: /spec/template/spec/securityContext/seLinuxOptions
   value: {"type":"spc_t"}

--- a/openshift/operator-controller/manifests-experimental/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests-experimental/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -46,6 +46,7 @@ spec:
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --catalogd-cas-dir=/var/ca-certs
+            - --pull-cas-dir=/var/ca-certs
             - --v=${LOG_VERBOSITY}
             - --feature-gates=PreflightPermissions=true
             - --feature-gates=SingleOwnNamespaceInstallSupport=true
@@ -53,9 +54,6 @@ spec:
             - --global-pull-secret=openshift-config/pull-secret
           command:
             - /operator-controller
-          env:
-            - name: SSL_CERT_DIR
-              value: /var/ca-certs
           image: ${OPERATOR_CONTROLLER_IMAGE}
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
+++ b/openshift/operator-controller/manifests/20-deployment-openshift-operator-controller-operator-controller-controller-manager.yml
@@ -46,13 +46,11 @@ spec:
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key
             - --catalogd-cas-dir=/var/ca-certs
+            - --pull-cas-dir=/var/ca-certs
             - --v=${LOG_VERBOSITY}
             - --global-pull-secret=openshift-config/pull-secret
           command:
             - /operator-controller
-          env:
-            - name: SSL_CERT_DIR
-              value: /var/ca-certs
           image: ${OPERATOR_CONTROLLER_IMAGE}
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
There is a problem when the service-ca certificate is not available at pod start. This is an issue because the SystemCertPool is created from SSL_CERT_DIR, which may include the empty service-ca. The SystemCertPool is never regenerated during the lifetime of the program execution, so it will never get updated when the service-ca is filled. Thus, we need to use --pull-cas-dir to reference the CAs that we want to use. This will also allow OLMv1 to reload the service-ca when it is reloaded (after 2 years, mind you). Removing the SSL_CERT_DIR setting, and adding the --pull-cas-dir flag ought to be equivalent to what we have now (i.e. SSL_CERT_DIR and no --pull-cas-dir), except that rotation will be handled better.