### PR TITLE
NO-ISSUE: Remove bindata generation from build

### DIFF
--- a/openshift/tests-extension/Makefile
+++ b/openshift/tests-extension/Makefile
@@ -84,7 +84,7 @@ pkg/bindata/catalog/catalog.go: $(shell find testdata/catalog -type f)
 # It prevents various FIPS compliance policies from being applied to this compilation.
 # Do not set globally.
 .PHONY: build
-build: bindata #HELP Build the extended tests binary
+build: #HELP Build the extended tests binary
 	@mkdir -p $(TOOLS_BIN_DIR)
 	GO_COMPLIANCE_POLICY="exempt_all" go build -ldflags "$(LDFLAGS)" -mod=vendor -o $(TOOLS_BIN_DIR)/olmv1-tests-ext ./cmd/...
 
@@ -125,7 +125,7 @@ update-metadata: #HELP Build and run 'update-metadata' to generate test metadata
 # This will regenerate the metadata without the test entry.
 #────────────────────────────────────────────────────────────────────
 .PHONY: build-update
-build-update: build update-metadata #HELP Build and update metadata and sanitize output
+build-update: bindata build update-metadata #HELP Build and update metadata and sanitize output
 
 #SECTION Metadata
 


### PR DESCRIPTION
Using go-bindata is causing problems with ART builds.

This removes the use of go-bindata from the builds.

This will subsequently require that users MANUALLY run the `bindata` target to refresh the bindata, or use the `build-update` target.

This is a quickfix to put out the fire.