### PR TITLE
NO-ISSUE: Remove test with issue scenario that cause need to revert all webhook tests

### DIFF
--- a/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
+++ b/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
@@ -80,16 +80,6 @@
     "environmentSelector": {}
   },
   {
-    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate rotation",
-    "labels": {},
-    "resources": {
-      "isolation": {}
-    },
-    "source": "openshift:payload:olmv1",
-    "lifecycle": "blocking",
-    "environmentSelector": {}
-  },
-  {
     "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion",
     "labels": {},
     "resources": {


### PR DESCRIPTION
Because of the problem reported here: [Slack thread](https://redhat-internal.slack.com/archives/C06KP34REFJ/p1755195055916089),
The entire PR was reverted last week: [#434](https://github.com/openshift/operator-framework-operator-controller/pull/434).

However, the bumper/sync process re-added the changes.
In this PR, I’m removing the problematic test. This seems like the simplest way to fix the bumper issue while keeping the other tests, which we do want to include.