### PR TITLE
OCPBUGS-60564: [OTE] Add webhook to validate openshift-service-ca certificate rotation

### DIFF
--- a/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
+++ b/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
@@ -140,6 +140,16 @@
     "environmentSelector": {}
   },
   {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate rotation",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  },
+  {
     "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion",
     "labels": {},
     "resources": {

--- a/openshift/tests-extension/test/webhooks.go
+++ b/openshift/tests-extension/test/webhooks.go
@@ -29,10 +29,12 @@ import (
 )
 
 const (
-	webhookCatalogName         = "webhook-operator-catalog"
-	webhookOperatorPackageName = "webhook-operator"
-	webhookOperatorCRDName     = "webhooktests.webhook.operators.coreos.io"
-	webhookServiceCert         = "webhook-operator-webhook-service-cert"
+	openshiftServiceCANamespace            = "openshift-service-ca"
+	openshiftServiceCASigningKeySecretName = "signing-key"
+	webhookCatalogName                     = "webhook-operator-catalog"
+	webhookOperatorPackageName             = "webhook-operator"
+	webhookOperatorCRDName                 = "webhooktests.webhook.operators.coreos.io"
+	webhookServiceCert                     = "webhook-operator-webhook-service-cert"
 )
 
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks",
@@ -84,7 +86,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 				helpers.DescribeAllClusterCatalogs(ctx)
 				helpers.DescribeAllClusterExtensions(ctx, webhookOperatorInstallNamespace)
 				By("dumping webhook diagnostics")
-				// Additional diagnostics specific for this test
 				helpers.RunAndPrint(ctx, "get", "mutatingwebhookconfigurations.admissionregistration.k8s.io", "-oyaml")
 				helpers.RunAndPrint(ctx, "get", "validatingwebhookconfigurations.admissionregistration.k8s.io", "-oyaml")
 			}
@@ -165,6 +166,76 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 					"mutate": true,
 				},
 			}))
+		})
+
+		It("should be tolerant to openshift-service-ca certificate rotation", func(ctx SpecContext) {
+			certificateSecretName := webhookServiceCert
+			var oldSecretResourceVersion string
+
+			By("ensuring the webhook operator's service certificate secret exists and getting its ResourceVersion")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: certificateSecretName, Namespace: webhookOperatorInstallNamespace}, secret)
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service certificate secret %s/%s", webhookOperatorInstallNamespace, certificateSecretName))
+				g.Expect(secret.Data).ToNot(BeEmpty(), "expected webhook service certificate secret data to not be empty")
+				oldSecretResourceVersion = secret.ResourceVersion
+				g.Expect(oldSecretResourceVersion).ToNot(BeEmpty(), "expected secret ResourceVersion to not be empty")
+			}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+			By("deleting the openshift-service-ca signing-key secret")
+			signingKeySecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      openshiftServiceCASigningKeySecretName,
+					Namespace: openshiftServiceCANamespace,
+				},
+			}
+			err := k8sClient.Delete(ctx, signingKeySecret, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+
+			By("waiting for the webhook operator's service certificate secret to be recreated with a new ResourceVersion")
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: certificateSecretName, Namespace: webhookOperatorInstallNamespace}, secret)
+				if apierrors.IsNotFound(err) {
+					GinkgoLogr.Info(fmt.Sprintf("Secret %s/%s not found yet (still polling for recreation)", webhookOperatorInstallNamespace, certificateSecretName))
+					return
+				}
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service certificate secret %s/%s: %v", webhookOperatorInstallNamespace, certificateSecretName, err))
+				g.Expect(secret.ResourceVersion).ToNot(Equal(oldSecretResourceVersion), "expected secret ResourceVersion to be different from the old one")
+				g.Expect(secret.Data).ToNot(BeEmpty(), "expected webhook service certificate secret data to not be empty after recreation")
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "webhook service certificate secret did not get recreated with a new ResourceVersion and populated within timeout")
+
+			By("checking webhook is responsive through cert rotation")
+			Eventually(func(g Gomega) {
+				resourceName := fmt.Sprintf("cert-rotation-test-%s", rand.String(5))
+				resource := newWebhookTest(resourceName, webhookOperatorInstallNamespace, true)
+
+				_, err := dynamicClient.Resource(webhookTestV1).Namespace(webhookOperatorInstallNamespace).Create(ctx, resource, metav1.CreateOptions{})
+				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to create test resource %s: %v", resourceName, err))
+
+				err = dynamicClient.Resource(webhookTestV1).Namespace(webhookOperatorInstallNamespace).Delete(ctx, resource.GetName(), metav1.DeleteOptions{})
+				g.Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred(), fmt.Sprintf("failed to delete test resource %s: %v", resourceName, err))
+			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+			DeferCleanup(func() {
+				// Specific check for this test
+				if CurrentSpecReport().Failed() {
+					By("dumping certificate details for debugging")
+					secret := &corev1.Secret{}
+					if err := k8sClient.Get(ctx, client.ObjectKey{
+						Name:      webhookServiceCert,
+						Namespace: webhookOperatorInstallNamespace,
+					}, secret); err == nil {
+						if crt, ok := secret.Data["tls.crt"]; ok && len(crt) > 0 {
+							printTLSCertInfo(crt)
+						} else {
+							_, _ = GinkgoWriter.Write([]byte("[diag] tls.crt key not found or empty in secret\n"))
+						}
+					} else {
+						fmt.Fprintf(GinkgoWriter, "[diag] failed to get secret for cert dump: %v\n", err)
+					}
+				}
+			})
 		})
 
 		It("should be tolerant to tls secret deletion", func(ctx SpecContext) {


### PR DESCRIPTION
This PR introduces the test that we faced intermitent issues in the OCP test env.

You can compare the migration from original: https://github.com/openshift/origin/pull/30059/files#diff-6dd6fa78ac85235012d3c9910f8510bc1640c830a83888681bd5922cec0dffcbR149-R164

**What fixed the test:**

- We wait for the webhook service cert secret to be recreated and populated before checking responsiveness.
- We use longer timeouts, since the short ones were too tight for these envs

**Tests**

(agreggate 10 times)
See details on https://pr-payload-tests.ci.openshift.org/runs/ci/52b277e0-7df6-11f0-99c5-0f4a557cd6de-0

```
 Will run 1 of 1 specs
  ------------------------------
  [sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate rotation
  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/webhooks.go:171
    STEP: initializing Kubernetes client @ 08/20/25 19:43:20.431
    STEP: requiring OLMv1 capability on OpenShift @ 08/20/25 19:43:20.431
    STEP: ensuring no ClusterExtension and CRD from a previous run @ 08/20/25 19:43:20.565
    STEP: checking if the webhook-operator-catalog exists @ 08/20/25 19:43:20.817
    STEP: webhook-operator catalog webhook-operator-catalog already exists, skipping creation @ 08/20/25 19:43:20.947
    STEP: installing the webhook operator in namespace webhook-operator-6xmxx @ 08/20/25 19:43:20.947
    STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 08/20/25 19:43:21.332
    STEP: waiting for the webhook operator to be installed @ 08/20/25 19:43:21.718
    STEP: waiting for the webhook operator's service to be ready @ 08/20/25 19:43:25.226
    STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 08/20/25 19:43:25.351
    STEP: ensuring the webhook operator's service certificate secret exists and getting its ResourceVersion @ 08/20/25 19:43:25.487
    STEP: deleting the openshift-service-ca signing-key secret @ 08/20/25 19:43:25.645
    STEP: waiting for the webhook operator's service certificate secret to be recreated with a new ResourceVersion @ 08/20/25 19:43:25.774
    STEP: checking webhook is responsive through cert rotation @ 08/20/25 19:44:36.874
    STEP: performing webhook operator cleanup @ 08/20/25 19:44:57.516
    STEP: cleanup: deleting ClusterExtension webhook-operator-6xmxx @ 08/20/25 19:44:57.516
    STEP: cleanup: deleting ClusterRoleBinding webhook-operator-6xmxx-operator-crb @ 08/20/25 19:44:57.66
    STEP: cleanup: deleting ServiceAccount webhook-operator-6xmxx-installer in namespace webhook-operator-6xmxx @ 08/20/25 19:44:57.804
    STEP: cleanup: deleting namespace webhook-operator-6xmxx @ 08/20/25 19:44:57.938
    STEP: waiting for namespace webhook-operator-6xmxx to be fully deleted @ 08/20/25 19:44:58.074
  • [205.468 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 205.468 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
  ===============================================================================================================
  Random Seed: 1755715343 - will randomize all specs
```