### PR TITLE
NO-ISSUE: Grant QE approver permissions for OTE contributions

### DIFF
--- a/openshift/tests-extension/OWNERS
+++ b/openshift/tests-extension/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - Xia-Zhao-rh
+  - kuiwang02
+  - bandrade
+  - jianzhangbjz
+reviewers:
+  - Xia-Zhao-rh
+  - kuiwang02
+  - bandrade
+  - jianzhangbjz
+


### PR DESCRIPTION
The current owners are defined in [OWNERS_ALIASES](https://github.com/openshift/operator-framework-operator-controller/blob/main/OWNERS_ALIASES). However, with the OTE process, more and more QE test cases will be contributed to this folder. It would be better if QE also had approval permissions.
Hi @oceanc80 and @joelanford , could you help approve it when you get a chance? Thanks!