### PR TITLE
NO-ISSUE: UPSTREAM: <carry>: Enhance clenup cluster catalog created for webhook…

### DIFF
--- a/openshift/tests-extension/test/webhooks.go
+++ b/openshift/tests-extension/test/webhooks.go
@@ -95,6 +95,10 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 			}
 		})
 
+		AfterAll(func(ctx SpecContext) {
+			helpers.EnsureCleanupClusterCatalog(ctx, webhookCatalogName)
+		})
+
 		It("should have a working validating webhook", func(ctx SpecContext) {
 			By("creating a webhook test resource that will be rejected by the validating webhook")
 			Eventually(func() error {


### PR DESCRIPTION
To validate the cleanup of the solution Cursor was used to generate a comprehensive script.

**Before the changes**
<img width="369" height="468" alt="Screenshot 2025-08-28 at 14 58 49" src="https://github.com/user-attachments/assets/d0b4467f-f6ba-4049-9505-59e1b83b68fc" />

**After we cleanup the webhook catalog**

<img width="351" height="335" alt="Screenshot 2025-08-28 at 15 40 21" src="https://github.com/user-attachments/assets/d68f2bfa-5194-438d-ab7d-a3849a73bf59" />


```
✅ Tests completed successfully
Step 3: Capturing after-test state...
Capturing comprehensive cluster state to after-test.out...
State captured successfully to after-test.out
Step 4: Analyzing cleanup effectiveness...
Analyzing cleanup effectiveness...
Analysis complete. Results saved to /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/output.result
=== FINAL RESULTS ===
=== CLEANUP VALIDATION ANALYSIS: Thu Aug 28 15:35:07 BST 2025 ===

=== DIFF SUMMARY ===
⚠️  DIFFERENCES DETECTED: Analyzing changes...

=== DETAILED DIFF ===
--- before-test.out     2025-08-28 15:31:07
+++ after-test.out      2025-08-28 15:35:07
@@ -1,4 +1,4 @@
-=== CLUSTER STATE CAPTURE: Thu Aug 28 15:30:47 BST 2025 ===
+=== CLUSTER STATE CAPTURE: Thu Aug 28 15:34:49 BST 2025 ===
 
 === NAMESPACES ===
 Namespace/default/2025-08-28T12:56:11Z
@@ -82,32 +82,40 @@
 Pod/default/verify-all-openshiftcertifiedoperators-57hvs-78xv4/Succeeded/2025-08-28T14:08:16Z
 Pod/default/verify-all-openshiftcertifiedoperators-6q5b9-bq5zs/Succeeded/2025-08-28T14:16:55Z
 Pod/default/verify-all-openshiftcertifiedoperators-gz5z5-6cxtw/Succeeded/2025-08-28T13:52:35Z
+Pod/default/verify-all-openshiftcertifiedoperators-ttkww-9qds2/Succeeded/2025-08-28T14:31:51Z
 Pod/default/verify-all-openshiftcommunityoperators-6pnvr-xwjvl/Succeeded/2025-08-28T14:16:10Z
+Pod/default/verify-all-openshiftcommunityoperators-mjg74-ftdk5/Succeeded/2025-08-28T14:31:48Z
 Pod/default/verify-all-openshiftcommunityoperators-ntnbs-c7m4t/Succeeded/2025-08-28T14:24:40Z
 Pod/default/verify-all-openshiftcommunityoperators-qqbnj-lv7pw/Succeeded/2025-08-28T13:51:39Z
 Pod/default/verify-all-openshiftcommunityoperators-xx78t-8w69n/Succeeded/2025-08-28T14:08:14Z
 Pod/default/verify-all-openshiftredhatmarketplace-hrsh4-hlkmp/Succeeded/2025-08-28T14:16:53Z
+Pod/default/verify-all-openshiftredhatmarketplace-nllmf-h2cng/Succeeded/2025-08-28T14:31:49Z
 Pod/default/verify-all-openshiftredhatmarketplace-p27s7-vlzmc/Succeeded/2025-08-28T14:08:15Z
 Pod/default/verify-all-openshiftredhatmarketplace-spsk2-g747g/Succeeded/2025-08-28T13:52:37Z
 Pod/default/verify-all-openshiftredhatmarketplace-tj4np-fvvrn/Succeeded/2025-08-28T14:24:36Z
 Pod/default/verify-all-openshiftredhatoperators-62vcj-rrc4v/Succeeded/2025-08-28T14:16:52Z
 Pod/default/verify-all-openshiftredhatoperators-d2gqw-mk98n/Succeeded/2025-08-28T13:52:36Z
+Pod/default/verify-all-openshiftredhatoperators-fqgrh-ptkts/Succeeded/2025-08-28T14:31:46Z
 Pod/default/verify-all-openshiftredhatoperators-tjw2c-vnjs2/Succeeded/2025-08-28T14:24:34Z
 Pod/default/verify-all-openshiftredhatoperators-xgdnk-cjrmn/Succeeded/2025-08-28T14:08:16Z
 Pod/default/verify-metas-openshiftcertifiedoperators-9rg76-xx4b2/Succeeded/2025-08-28T14:16:53Z
 Pod/default/verify-metas-openshiftcertifiedoperators-bt662-h2947/Succeeded/2025-08-28T14:08:21Z
 Pod/default/verify-metas-openshiftcertifiedoperators-htvsj-l7tpn/Succeeded/2025-08-28T13:52:38Z
 Pod/default/verify-metas-openshiftcertifiedoperators-hxl58-lk46h/Succeeded/2025-08-28T14:24:40Z
+Pod/default/verify-metas-openshiftcertifiedoperators-jwn9j-zwtlk/Succeeded/2025-08-28T14:31:50Z
 Pod/default/verify-metas-openshiftcommunityoperators-96wkb-4pvfd/Succeeded/2025-08-28T14:24:37Z
 Pod/default/verify-metas-openshiftcommunityoperators-dmgmh-46rpz/Succeeded/2025-08-28T14:16:54Z
 Pod/default/verify-metas-openshiftcommunityoperators-lnsxp-ft5ct/Succeeded/2025-08-28T13:51:39Z
 Pod/default/verify-metas-openshiftcommunityoperators-w7hp7-jtmf9/Succeeded/2025-08-28T14:08:22Z
+Pod/default/verify-metas-openshiftcommunityoperators-wdzkn-pxd44/Succeeded/2025-08-28T14:31:50Z
+Pod/default/verify-metas-openshiftredhatmarketplace-j52b7-9hdkv/Succeeded/2025-08-28T14:31:48Z
 Pod/default/verify-metas-openshiftredhatmarketplace-j9g9g-rlrp5/Succeeded/2025-08-28T14:16:55Z
 Pod/default/verify-metas-openshiftredhatmarketplace-mqnmc-wlmjm/Succeeded/2025-08-28T13:52:36Z
 Pod/default/verify-metas-openshiftredhatmarketplace-rzc4l-rwxq7/Succeeded/2025-08-28T14:08:22Z
 Pod/default/verify-metas-openshiftredhatmarketplace-zk7l8-gczz4/Succeeded/2025-08-28T14:24:38Z
 Pod/default/verify-metas-openshiftredhatoperators-b6rls-88vdl/Succeeded/2025-08-28T14:08:14Z
 Pod/default/verify-metas-openshiftredhatoperators-hwhhr-h5c7s/Succeeded/2025-08-28T14:16:51Z
+Pod/default/verify-metas-openshiftredhatoperators-stj5x-24r7h/Succeeded/2025-08-28T14:31:47Z
 Pod/default/verify-metas-openshiftredhatoperators-v2bd2-57mpp/Succeeded/2025-08-28T14:24:39Z
 Pod/default/verify-metas-openshiftredhatoperators-wm67d-5lwmc/Succeeded/2025-08-28T13:52:38Z
 Pod/openshift-apiserver-operator/openshift-apiserver-operator-5756666865-4drr9/Running/2025-08-28T12:59:18Z
@@ -307,7 +315,6 @@
 Pod/openshift-machine-config-operator/machine-config-server-mhrjt/Running/2025-08-28T13:03:21Z
 Pod/openshift-machine-config-operator/machine-config-server-txnk7/Running/2025-08-28T13:03:21Z
 Pod/openshift-marketplace/certified-operators-84z52/Running/2025-08-28T13:13:49Z
-Pod/openshift-marketplace/certified-operators-pj52j/Running/2025-08-28T14:30:43Z
 Pod/openshift-marketplace/community-operators-52rm4/Running/2025-08-28T13:13:49Z
 Pod/openshift-marketplace/marketplace-operator-597b8598f9-fr25s/Running/2025-08-28T12:59:19Z
 Pod/openshift-marketplace/redhat-marketplace-q7cjv/Running/2025-08-28T13:13:52Z
@@ -3344,4 +3351,4 @@
 --- Webhook Test Resources ---
 No webhook test resources found
 
-=== END CAPTURE: Thu Aug 28 15:31:07 BST 2025 ===
+=== END CAPTURE: Thu Aug 28 15:35:07 BST 2025 ===

=== LEFTOVER RESOURCE ANALYSIS ===
--- Checking for test-related leftovers ---
🔍 ClusterCatalogs:
✅ No test ClusterCatalogs found
🔍 ClusterExtensions:
✅ No test ClusterExtensions found
🔍 Test Namespaces:
✅ No test namespaces found
🔍 Test ClusterRoles:
✅ No test ClusterRoles found
🔍 Test ClusterRoleBindings:
✅ No test ClusterRoleBindings found
🔍 Webhook Configurations:
✅ No test webhook configurations found
🔍 Jobs in default namespace:
✅ No test jobs found in default namespace
🔍 Test CRDs:
✅ No test-related CRDs found
🔍 OpenShift Build/Image resources:
✅ No test build/image resources found

=== CLEANUP EFFECTIVENESS SUMMARY ===
🎉 EXCELLENT: Complete cleanup detected - no test resources left behind
Cleanup Score: 100%
Total leftover categories: 0

=== ANALYSIS COMPLETE: Thu Aug 28 15:35:11 BST 2025 ===
Comprehensive cleanup validation complete!
```

See attached the scripts used:

- [comprehensive_cleanup_validation.sh](https://github.com/user-attachments/files/22027727/comprehensive_cleanup_validation.sh)

- [output.result.txt](https://github.com/user-attachments/files/22027788/output.result.txt)
