### PR TITLE
OCPBUGS-61213: [OTE] Update webhook ote tests to use latest webhook-operator

### DIFF
--- a/openshift/tests-extension/pkg/bindata/catalog/catalog.go
+++ b/openshift/tests-extension/pkg/bindata/catalog/catalog.go
@@ -94,7 +94,7 @@ func dockerfile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "Dockerfile", size: 97, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "Dockerfile", size: 97, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -114,7 +114,7 @@ func configsIndexignore() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "configs/.indexignore", size: 4, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "configs/.indexignore", size: 4, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -134,7 +134,7 @@ func configsIndexYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "configs/index.yaml", size: 615, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "configs/index.yaml", size: 615, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/openshift/tests-extension/pkg/bindata/operator/operator.go
+++ b/openshift/tests-extension/pkg/bindata/operator/operator.go
@@ -96,7 +96,7 @@ func dockerfile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "Dockerfile", size: 888, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "Dockerfile", size: 888, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func manifestsRegistryClusterserviceversionYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "manifests/registry.clusterserviceversion.yaml", size: 3879, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "manifests/registry.clusterserviceversion.yaml", size: 3879, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func metadataAnnotationsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "metadata/annotations.yaml", size: 732, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "metadata/annotations.yaml", size: 732, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func metadataPropertiesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "metadata/properties.yaml", size: 67, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "metadata/properties.yaml", size: 67, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func testsScorecardConfigYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tests/scorecard/config.yaml", size: 1614, mode: os.FileMode(420), modTime: time.Unix(1755024325, 0)}
+	info := bindataFileInfo{name: "tests/scorecard/config.yaml", size: 1614, mode: os.FileMode(420), modTime: time.Unix(1756998653, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Due to kube-rbac-proxy deprecation the webhook-operator (created 5 years ago) started to create problems downstream [[link](https://redhat-internal.slack.com/archives/C017UFPQA4X/p1756816199741369)].

As a mitigation I've recreated the webhook-operator using a latest version of kubebuilder [here](github.com/perdasilva/webhook-operator). We should definitely eventually move to an in-tree test-operator.