### PR TITLE
NO-ISSUE: add jiazha to approvers

### DIFF
--- a/DOWNSTREAM_OWNERS_ALIASES
+++ b/DOWNSTREAM_OWNERS_ALIASES
@@ -7,6 +7,7 @@ aliases:
    - oceanc80
    - perdasilva
    - tmshort
+   - jianzhangbjz
 
    # contributors who can review/lgtm any PRs in the repo
    operator-framework-reviewers:


### PR DESCRIPTION
It seems that https://github.com/openshift/operator-framework-operator-controller/pull/457 doesn’t work as expected based on https://github.com/openshift/operator-framework-operator-controller/pull/467#issuecomment-3294450227. Therefore, I’ve created a new PR to add the QE leader to the downstream approvers.