### PR TITLE
OPRUN-4160: Fix cp-manifests copying of helm charts

### DIFF
--- a/openshift/catalogd/cp-manifests
+++ b/openshift/catalogd/cp-manifests
@@ -19,6 +19,6 @@ fi
 
 if [ -d /openshift/helm ]; then
     mkdir -p "${DEST}/helm/catalogd"
-    cp -a /openshift/helm "${DEST}/helm/catalogd"
+    cp -a /openshift/helm/* "${DEST}/helm/catalogd"
 fi
 

--- a/openshift/operator-controller/cp-manifests
+++ b/openshift/operator-controller/cp-manifests
@@ -19,6 +19,6 @@ fi
 
 if [ -d /openshift/helm ]; then
     mkdir -p "${DEST}/helm/operator-controller"
-    cp -a /openshift/helm "${DEST}/helm/operator-controller"
+    cp -a /openshift/helm/* "${DEST}/helm/operator-controller"
 fi
 


### PR DESCRIPTION
The method used to copy the helm charts is including an extra `helm` directory in the destination path, that is making the cluster-olm-operator code just a bit more complicated than it needs to be.

This fixes the copy location.