### PR TITLE
Don't use short-name

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -129,7 +129,7 @@ func (c *MetricsTestConfig) getServiceAccountToken(t *testing.T) string {
 func (c *MetricsTestConfig) createCurlMetricsPod(t *testing.T) {
 	t.Logf("Creating curl pod (%s/%s) to validate the metrics endpoint", c.namespace, c.curlPodName)
 	cmd := exec.Command(c.client, "run", c.curlPodName,
-		"--image=curlimages/curl:8.15.0",
+		"--image=quay.io/curl/curl:8.15.0",
 		"--namespace", c.namespace,
 		"--restart=Never",
 		"--overrides", `{
@@ -137,7 +137,7 @@ func (c *MetricsTestConfig) createCurlMetricsPod(t *testing.T) {
 				"terminationGradePeriodSeconds": 0,
 				"containers": [{
 					"name": "curl",
-					"image": "curlimages/curl:8.15.0",
+					"image": "quay.io/curl/curl:8.15.0",
 					"command": ["sh", "-c", "sleep 3600"],
 					"securityContext": {
 						"allowPrivilegeEscalation": false,


### PR DESCRIPTION
Try to address https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_operator-framework-operator-controller/484/pull-ci-openshift-operator-framework-operator-controller-main-openshift-e2e-aws/1970899227856867328/build-log.txt
```console
    metrics_test.go:162: 
        	Error Trace:	/go/src/github.com/openshift/operator-framework-operator-controller/test/e2e/metrics_test.go:162
        	            				/go/src/github.com/openshift/operator-framework-operator-controller/test/e2e/metrics_test.go:102
        	            				/go/src/github.com/openshift/operator-framework-operator-controller/test/e2e/metrics_test.go:48
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestOperatorControllerMetricsExportedEndpoint
        	Messages:   	Error waiting for curl pod to be ready: error: timed out waiting for the condition on pods/oper-curl-metrics
```
```console
        Events:
          Type     Reason          Age                From               Message
          ----     ------          ----               ----               -------
          Normal   Scheduled       60s                default-scheduler  Successfully assigned testns-swmtc7tc/oper-curl-metrics to ip-10-0-67-225.ec2.internal
          Normal   AddedInterface  59s                multus             Add eth0 [10.128.2.19/23] from ovn-kubernetes
          Warning  InspectFailed   13s (x6 over 59s)  kubelet            Failed to inspect image "": rpc error: code = Unknown desc = short name mode is enforcing, but image name curlimages/curl:8.15.0 returns ambiguous list
          Warning  Failed          13s (x6 over 59s)  kubelet            Error: ImageInspectError
```
More on Slack: https://redhat-internal.slack.com/archives/C06KP34REFJ/p1758735242789949