### PR TITLE
OCPBUGS-62811: for incompatible test add func to wait builder and deployer SA creation by OCP controller

### DIFF
--- a/openshift/tests-extension/pkg/helpers/cluster_extension.go
+++ b/openshift/tests-extension/pkg/helpers/cluster_extension.go
@@ -185,7 +185,7 @@ func ExpectServiceAccountExists(ctx context.Context, name, namespace string) {
 	Eventually(func(g Gomega) {
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, sa)
 		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get ServiceAccount %q/%q: %v", namespace, name, err))
-	}).WithTimeout(10*time.Second).WithPolling(1*time.Second).Should(Succeed(), "ServiceAccount %q/%q did not become visible within timeout", namespace, name)
+	}).WithTimeout(5*time.Minute).WithPolling(3*time.Second).Should(Succeed(), "ServiceAccount %q/%q did not become visible within timeout", namespace, name)
 }
 
 // ExpectClusterRoleBindingExists waits for a ClusterRoleBinding to be available and visible to the client.

--- a/openshift/tests-extension/test/olmv1-incompatible.go
+++ b/openshift/tests-extension/test/olmv1-incompatible.go
@@ -68,6 +68,13 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 		nsCleanup := createNamespace(nsName)
 		DeferCleanup(nsCleanup)
 
+		// The builder (and deployer) service accounts are created by OpenShift itself which injects them in the NS.
+		By(fmt.Sprintf("waiting for builder serviceaccount in %s", nsName))
+		helpers.ExpectServiceAccountExists(ctx, "builder", nsName)
+
+		By(fmt.Sprintf("waiting for deployer serviceaccount in %s", nsName))
+		helpers.ExpectServiceAccountExists(ctx, "deployer", nsName)
+
 		By("applying image-puller RoleBinding")
 		rbCleanup := createImagePullerRoleBinding(rbName, nsName)
 		DeferCleanup(rbCleanup)


### PR DESCRIPTION
Cheery-pick of https://github.com/openshift/operator-framework-operator-controller/pull/501