### PR TITLE
NO-ISSUE: UPSTREAM: <carry>: check kubeconfig only run-test and run-suite

### DIFF
--- a/openshift/tests-extension/cmd/main.go
+++ b/openshift/tests-extension/cmd/main.go
@@ -289,7 +289,30 @@ func main() {
 		Long: "OLMv1 Tests Extension",
 	}
 
-	root.AddCommand(cmd.DefaultExtensionCommands(registry)...)
+	// Get all default commands from the extension framework
+	allCommands := cmd.DefaultExtensionCommands(registry)
+
+	// Add KUBECONFIG check to run-suite and run-test commands only.
+	// Other commands (list, info, images, update, completion, help) don't need KUBECONFIG.
+	for _, command := range allCommands {
+		// Identify run-suite and run-test commands by their Use field
+		if command.Use == "run-suite NAME" || command.Use == "run-test [-n NAME...] [NAME]" {
+			// Save the original RunE function
+			originalRunE := command.RunE
+
+			// Wrap it with KUBECONFIG check
+			command.RunE = func(cmd *cobra.Command, args []string) error {
+				// Check KUBECONFIG before running the test
+				if err := exutil.CheckKubeconfigSet(); err != nil {
+					return err
+				}
+				// Call the original RunE function
+				return originalRunE(cmd, args)
+			}
+		}
+	}
+
+	root.AddCommand(allCommands...)
 
 	if err := func() error {
 		return root.Execute()

--- a/openshift/tests-extension/test/qe/util/framework.go
+++ b/openshift/tests-extension/test/qe/util/framework.go
@@ -22,13 +22,6 @@ import (
 	testdata "github.com/openshift/operator-framework-operator-controller/openshift/tests-extension/pkg/bindata/qe"
 )
 
-func init() {
-	if KubeConfigPath() == "" {
-		fmt.Fprintf(os.Stderr, "Please set KUBECONFIG first!\n")
-		os.Exit(0)
-	}
-}
-
 // WaitForServiceAccount waits until the named service account gets fully
 // provisioned
 func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string, checkSecret bool) error {

--- a/openshift/tests-extension/test/qe/util/init.go
+++ b/openshift/tests-extension/test/qe/util/init.go
@@ -9,6 +9,23 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
+// CheckKubeconfigSet verifies that the KUBECONFIG environment variable is set and points to a valid file.
+// This check is only required for commands that interact with a Kubernetes cluster (run-suite and run-test).
+// Other commands (list, info, images, update, completion, help) do not require KUBECONFIG.
+func CheckKubeconfigSet() error {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return fmt.Errorf("KUBECONFIG environment variable is not set.\nPlease set KUBECONFIG to point to your cluster configuration file.\nExample: export KUBECONFIG=/path/to/kubeconfig")
+	}
+
+	// Check if kubeconfig file exists
+	if _, err := os.Stat(kubeconfig); err != nil {
+		return fmt.Errorf("KUBECONFIG file does not exist: %s (error: %v)", kubeconfig, err)
+	}
+
+	return nil
+}
+
 // InitClusterEnv initializes the cluster environment for testing by setting up test framework and configuration
 // This function will panic if initialization fails
 func InitClusterEnv() {


### PR DESCRIPTION
  **Only require KUBECONFIG for run-suite and run-test commands**

  **Problem**

  Previously, the olmv1-tests-ext binary required the KUBECONFIG environment variable to be set for all subcommands, including those that don't
  interact with a cluster (like list, info, images, update, completion, and help). This was due to an init() function in
  test/qe/util/framework.go that checked KUBECONFIG during package initialization and exited immediately if it wasn't set.


  **Solution**

  This PR implements a targeted approach where only commands that actually need cluster access (run-suite and run-test) require KUBECONFIG:

  1. Removed the global init() check from test/qe/util/framework.go that was blocking all commands
  2. Added CheckKubeconfigSet() function to test/qe/util/init.go that validates KUBECONFIG and provides helpful error messages
  3. Implemented command-level validation in cmd/main.go by wrapping the RunE handlers for run-suite and run-test commands with KUBECONFIG checks

  **Changes**

  - test/qe/util/framework.go: Removed init() function (lines 25-30)
  - test/qe/util/init.go: Added CheckKubeconfigSet() function with validation and helpful error messages
  - cmd/main.go: Added command wrapping logic to enforce KUBECONFIG requirement only for cluster-dependent commands

  **Testing**

  Verified the following behavior:

  ✅ Commands that work WITHOUT KUBECONFIG:
  $ unset KUBECONFIG
  $ ./bin/olmv1-tests-ext list --help        # ✓ Works
  $ ./bin/olmv1-tests-ext info               # ✓ Works  
  $ ./bin/olmv1-tests-ext images             # ✓ Works
  $ ./bin/olmv1-tests-ext completion bash    # ✓ Works

```console
make update-metadata
/Users/kuiwang/GoProject/go-origin/src/github.com/openshift/operator-framework-operator-controller/openshift/tests-extension/bin/olmv1-tests-ext update --component openshift:payload:olmv1
successfully updated metadata
/Applications/Xcode.app/Contents/Developer/usr/bin/make clean-metadata
Cleaning metadata (removing codeLocations)...
```

  ❌ Commands that REQUIRE KUBECONFIG:
  $ unset KUBECONFIG
  $ ./bin/olmv1-tests-ext run-suite olmv1/parallel
  Error: KUBECONFIG environment variable is not set.
  Please set KUBECONFIG to point to your cluster configuration file.
  Example: export KUBECONFIG=/path/to/kubeconfig

  $ ./bin/olmv1-tests-ext run-test "test-name"
  Error: KUBECONFIG environment variable is not set.
  Please set KUBECONFIG to point to your cluster configuration file.
  Example: export KUBECONFIG=/path/to/kubeconfig

Assisted-by: Claude Code

/cc @perdasilva 