### PR TITLE
OCPBUGS-62517: UPSTREAM: <carry>: add rollingUpdate strategy

### DIFF
--- a/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
@@ -13,6 +13,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager

--- a/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
@@ -12,6 +12,11 @@ metadata:
   namespace: {{ .Values.namespaces.olmv1.name }}
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -2003,6 +2003,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -2148,6 +2153,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -1928,6 +1928,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -2061,6 +2066,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -1762,6 +1762,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -1906,6 +1911,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -1687,6 +1687,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager
@@ -1819,6 +1824,11 @@ metadata:
   namespace: olmv1-system
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1          # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0    # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/openshift/catalogd/manifests-experimental.yaml
+++ b/openshift/catalogd/manifests-experimental.yaml
@@ -835,6 +835,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1 # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0 # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager

--- a/openshift/catalogd/manifests.yaml
+++ b/openshift/catalogd/manifests.yaml
@@ -835,6 +835,11 @@ metadata:
 spec:
   minReadySeconds: 5
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1 # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0 # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: catalogd-controller-manager

--- a/openshift/operator-controller/manifests-experimental.yaml
+++ b/openshift/operator-controller/manifests-experimental.yaml
@@ -1285,6 +1285,11 @@ metadata:
   namespace: openshift-operator-controller
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1 # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0 # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager

--- a/openshift/operator-controller/manifests.yaml
+++ b/openshift/operator-controller/manifests.yaml
@@ -1054,6 +1054,11 @@ metadata:
   namespace: openshift-operator-controller
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1 # Allow temporary 2 pods (1 + 1) for zero-downtime updates
+      maxUnavailable: 0 # Never allow pods to be unavailable during updates
   selector:
     matchLabels:
       control-plane: operator-controller-controller-manager


### PR DESCRIPTION
Try to address OCPBUGS-62517, don't use the defaut
```yaml
  replicas: 1
  strategy:
    rollingUpdate:
      maxSurge: 25%        
      maxUnavailable: 25%
```
Because `maxUnavailable: 25%`  -> At minimum, the number of available Pods can be as low as `replicas - maxUnavailable = 1 - 1 = 0`. During the update process, there may be a brief period of unavailability (0 available Pods). 