### PR TITLE
OPRUN-4194: Update OCP catalogs to v4.21

### DIFF
--- a/openshift/catalogd/manifests-experimental.yaml
+++ b/openshift/catalogd/manifests-experimental.yaml
@@ -1005,7 +1005,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/certified-operator-index:v4.20
+      ref: registry.redhat.io/redhat/certified-operator-index:v4.21
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-community-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1018,7 +1018,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/community-operator-index:v4.20
+      ref: registry.redhat.io/redhat/community-operator-index:v4.21
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-marketplace.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1031,7 +1031,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.20
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.21
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1044,7 +1044,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-operator-index:v4.20
+      ref: registry.redhat.io/redhat/redhat-operator-index:v4.21
 ---
 # Source: olmv1/templates/mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
 apiVersion: admissionregistration.k8s.io/v1

--- a/openshift/catalogd/manifests.yaml
+++ b/openshift/catalogd/manifests.yaml
@@ -1004,7 +1004,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/certified-operator-index:v4.20
+      ref: registry.redhat.io/redhat/certified-operator-index:v4.21
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-community-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1017,7 +1017,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/community-operator-index:v4.20
+      ref: registry.redhat.io/redhat/community-operator-index:v4.21
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-marketplace.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1030,7 +1030,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.20
+      ref: registry.redhat.io/redhat/redhat-marketplace-index:v4.21
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1043,7 +1043,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-operator-index:v4.20
+      ref: registry.redhat.io/redhat/redhat-operator-index:v4.21
 ---
 # Source: olmv1/templates/mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
 apiVersion: admissionregistration.k8s.io/v1

--- a/openshift/helm/catalogd.yaml
+++ b/openshift/helm/catalogd.yaml
@@ -12,6 +12,8 @@ options:
     enabled: false
   openshift:
     enabled: true
+    catalogs:
+      version: v4.21
 
 # The set of namespaces
 namespaces:


### PR DESCRIPTION
Use the new method to update catalog versions.