### PR TITLE
OPRUN-4199: [Default Catalog Tests] - Change logic to get ocp images from openshift/catalogd/manifests.yaml

### DIFF
--- a/openshift/default-catalog-consistency/go.mod
+++ b/openshift/default-catalog-consistency/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/operator-framework/operator-controller v1.3.0
 	github.com/operator-framework/operator-registry v1.55.0
+	k8s.io/apimachinery v0.33.2
 	oras.land/oras-go/v2 v2.6.0
-	sigs.k8s.io/yaml v1.5.0
 )
 
 require (
@@ -130,7 +130,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.33.2 // indirect
-	k8s.io/apimachinery v0.33.2 // indirect
 	k8s.io/client-go v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250701173324-9bd5c66d9911 // indirect
@@ -139,4 +138,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
+	sigs.k8s.io/yaml v1.5.0 // indirect
 )

--- a/openshift/default-catalog-consistency/test/utils/utils.go
+++ b/openshift/default-catalog-consistency/test/utils/utils.go
@@ -1,68 +1,115 @@
 package utils
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	"sigs.k8s.io/yaml"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 
 	apiv1 "github.com/operator-framework/operator-controller/api/v1"
 )
 
 // ParseImageRefsFromCatalog reads the catalogs from the files used and returns a list of image references.
 func ParseImageRefsFromCatalog(catalogsPath string) ([]string, error) {
-	var images []string
-
 	re := regexp.MustCompile(`{{.*}}`)
 
-	// Check if the directory exists first
-	if _, err := os.Stat(catalogsPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("catalogs path %s does not exist", catalogsPath)
+	info, err := os.Stat(catalogsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("catalogs path %s does not exist", catalogsPath)
+		}
+		return nil, err
 	}
 
-	err := filepath.WalkDir(catalogsPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+	var (
+		images []string
+	)
 
-		if d.IsDir() || (!strings.HasSuffix(d.Name(), ".yaml") &&
-			!strings.HasSuffix(d.Name(), ".yml")) {
-			return nil
-		}
-
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return nil
-		}
-		// Replace any helm templating
-		content = re.ReplaceAll(content, []byte{})
-
-		var catalog apiv1.ClusterCatalog
-		if err := yaml.Unmarshal(content, &catalog); err != nil {
-			return nil
-		}
-
-		if catalog.Kind != "ClusterCatalog" {
-			return nil
-		}
-
-		if catalog.Spec.Source.Type == apiv1.SourceTypeImage && catalog.Spec.Source.Image != nil {
-			images = append(images, catalog.Spec.Source.Image.Ref)
-		}
-
-		return nil
-	})
-
+	if info.IsDir() {
+		images, err = parseCatalogDir(catalogsPath, re)
+	} else {
+		images, err = parseCatalogFile(catalogsPath, re)
+	}
 	if err != nil {
 		return nil, err
 	}
 
 	if len(images) == 0 {
 		return nil, fmt.Errorf("no images found under catalogs path %s", catalogsPath)
+	}
+
+	return images, nil
+}
+
+func parseCatalogDir(root string, re *regexp.Regexp) ([]string, error) {
+	var images []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if !strings.HasSuffix(d.Name(), ".yaml") && !strings.HasSuffix(d.Name(), ".yml") {
+			return nil
+		}
+
+		refs, err := parseCatalogFile(path, re)
+		if err != nil {
+			return err
+		}
+
+		images = append(images, refs...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
+func parseCatalogFile(path string, re *regexp.Regexp) ([]string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseClusterCatalogs(content, re)
+}
+
+func parseClusterCatalogs(content []byte, re *regexp.Regexp) ([]string, error) {
+	// Replace any helm templating
+	content = re.ReplaceAll(content, []byte{})
+
+	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(content), 4096)
+
+	var images []string
+	for {
+		var catalog apiv1.ClusterCatalog
+		if err := decoder.Decode(&catalog); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+
+		if catalog.Kind != "ClusterCatalog" {
+			continue
+		}
+
+		if catalog.Spec.Source.Type == apiv1.SourceTypeImage && catalog.Spec.Source.Image != nil {
+			images = append(images, catalog.Spec.Source.Image.Ref)
+		}
 	}
 
 	return images, nil

--- a/openshift/default-catalog-consistency/test/validate/suite_test.go
+++ b/openshift/default-catalog-consistency/test/validate/suite_test.go
@@ -23,7 +23,7 @@ func TestSuite(t *testing.T) {
 }
 
 var _ = Describe("OLM-Catalog-Validation", func() {
-	catalogsPath := "../../../../helm/olmv1/templates/openshift-catalogs"
+	catalogsPath := "../../../catalogd/manifests.yaml"
 	images, err := utils.ParseImageRefsFromCatalog(catalogsPath)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(images).ToNot(BeEmpty(), "no images found")


### PR DESCRIPTION
Test locally:

```
$ make test-catalog
go build -mod=vendor -o /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/default-catalog-consistency/bin/ginkgo ./vendor/github.com/onsi/ginkgo/v2/ginkgo
/Users/camilam/go/src/github/operator-framework-operator-controller/openshift/default-catalog-consistency/bin/ginkgo  \
		--junit-report=junit_olm.xml ./test/validate/...
2025/10/13 18:56:59 maxprocs: Leaving GOMAXPROCS=11: CPU quota undefined
Running Suite: OLM-Catalog-Validation - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/default-catalog-consistency/test/validate
===============================================================================================================================================================
Random Seed: 1760378219

Will run 8 of 8 specs
••••no default policy found for (registry.redhat.io/redhat/certified-operator-index:v4.20), using insecure policy 
```
