### PR TITLE
NO-ISSUE: UPSTREAM: <carry>: make webhook case in parallel as possible

### DIFF
--- a/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
+++ b/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
@@ -514,7 +514,20 @@
     "environmentSelector": {}
   },
   {
-    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should have a working validating webhook",
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - serial tests should be tolerant to tls secret deletion [Serial]",
+    "originalName": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion",
+    "labels": {
+      "original-name:[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion": {}
+    },
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  },
+  {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working validating webhook",
     "originalName": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working validating webhook",
     "labels": {
       "original-name:[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working validating webhook": {}
@@ -527,7 +540,7 @@
     "environmentSelector": {}
   },
   {
-    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should have a working mutating webhook [Serial]",
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working mutating webhook",
     "originalName": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working mutating webhook",
     "labels": {
       "original-name:[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working mutating webhook": {}
@@ -540,23 +553,10 @@
     "environmentSelector": {}
   },
   {
-    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should have a working conversion webhook [Serial]",
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working conversion webhook",
     "originalName": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working conversion webhook",
     "labels": {
       "original-name:[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working conversion webhook": {}
-    },
-    "resources": {
-      "isolation": {}
-    },
-    "source": "openshift:payload:olmv1",
-    "lifecycle": "blocking",
-    "environmentSelector": {}
-  },
-  {
-    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should be tolerant to tls secret deletion [Serial]",
-    "originalName": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion",
-    "labels": {
-      "original-name:[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion": {}
     },
     "resources": {
       "isolation": {}


### PR DESCRIPTION
  ## Summary

  Enable parallel execution for webhook operator tests to reduce overall test execution time. This PR splits the webhook tests into two groups: parallel tests (validating, mutating, and conversion webhooks) and serial tests (TLS secret deletion).

  ## Changes

  ### 1. Split Tests into Two Describe Blocks

  **Parallel Tests (Lines 42-177)**
  - Removed `Serial` marker from the Describe block
  - Removed `[Serial]` marker from individual test cases:
    - `should have a working validating webhook`
    - `should have a working mutating webhook`
    - `should have a working conversion webhook`
  - Removed cleanup call in `BeforeEach` to allow multiple ClusterExtensions to coexist

  **Serial Tests (Lines 180-306)**
  - New Describe block with `Serial` marker
  - Contains the TLS secret deletion test
  - Executes cleanup before running to ensure a clean environment

  ## Architecture Analysis

  ### Resource Isolation Strategy

  When parallel tests run in separate processes on the same cluster:

  **Per-Process Resources (Isolated)**
  - Namespace: `webhook-operator-<random>` (unique per test)
  - ClusterExtension: named after namespace (unique)
  - ServiceAccount, ClusterRoleBinding: namespace-scoped
  - Deployment, Service, Secret: namespace-scoped

  **Shared Resources (Cluster-Scoped)**
  - CRD: `webhooktests.webhook.operators.coreos.io` (shared)
  - MutatingWebhookConfiguration: multiple instances (uses generateName)
  - ValidatingWebhookConfiguration: multiple instances (uses generateName)

  ### CRD Conflict Resolution

  **Question**: When multiple ClusterExtensions try to install the same CRD simultaneously, what happens?

  **Answer**: OLM handles this gracefully because:
  1. **No OwnerReferences on CRDs**: CRDs created by OLM do not have ownerReferences pointing to ClusterExtension
  2. **Server-Side Apply (SSA)**: OLM uses SSA (see `boxcutter.go:226`), which allows multiple field managers to co-manage the same resource
  3. **By Design**: OLM is designed to support multiple operators sharing the same CRD

  **Evidence from Code**:
  ```go
  // internal/operator-controller/applier/boxcutter.go:67
  obj.SetOwnerReferences(nil) // reset OwnerReferences for migration

  // internal/operator-controller/applier/boxcutter.go:226
  return bc.Client.Patch(ctx, obj, client.Apply, client.FieldOwner(bc.FieldOwner), client.ForceOwnership)
```

  Cleanup Behavior

  When a ClusterExtension is deleted:
  - ✅ ClusterExtension itself is deleted
  - ✅ ClusterExtensionRevision is deleted (via ownerReference)
  - ✅ Namespace-scoped resources are deleted (via namespace deletion)
  - ✅ ClusterRoleBinding is deleted (via DeferCleanup)
  - ❌ CRD is NOT deleted (no ownerReference, managed via SSA)

  This behavior is intentional and allows parallel tests to safely delete their ClusterExtensions without affecting other running tests.

  Known Side Effects (Acceptable)

  1. Multiple Webhook Interceptors

  Each WebhookTest resource creation will be validated/mutated by all active webhook configurations (~3x in parallel execution).

  Impact:
  - Minor performance overhead (~3x network calls)
  - Potential timeout if one webhook is unreachable
  - Functional behavior should remain correct

  2. ConversionWebhook Namespace Mismatch

  The CRD contains a hardcoded namespace reference (webhook-operator-system), but actual deployments use random namespaces (webhook-operator-<random>).

  Impact:
  - May affect conversion webhook routing
  - Depends on whether OLM dynamically updates the CRD namespace reference
  - Conversion webhook test might experience issues, but validating/mutating tests should pass

  3. Cleanup Timing

  The serial test block uses helpers.EnsureCleanupClusterExtension() to clean up all ClusterExtensions and the shared CRD before running. This ensures the TLS deletion test runs in a clean environment.

  Testing Strategy

  Execution Flow

  Phase 1: Parallel Tests (Processes 1-3)
  T0: All processes start simultaneously
    ├─ Process 1: Creates CE "webhook-operator-abc12" → OLM creates CRD ✅
    ├─ Process 2: Creates CE "webhook-operator-def34" → OLM detects existing CRD, validates, continues ✅
    └─ Process 3: Creates CE "webhook-operator-ghi56" → OLM detects existing CRD, validates, continues ✅

  T1: All tests execute in parallel
    └─ Each test uses its isolated namespace and resources

  T2: Tests complete and clean up
    ├─ Process 1: Deletes CE (CRD remains) ✅
    ├─ Process 2: Deletes CE (CRD remains) ✅
    └─ Process 3: Deletes CE (CRD remains) ✅

  Phase 2: Serial Test (After all parallel tests complete)
  T3: Serial test starts
    ├─ Cleanup all remaining ClusterExtensions
    ├─ Delete shared CRD
    ├─ Create fresh ClusterExtension
    └─ Run TLS deletion test

  Verification Plan (run them more times and all pass)

```console
INFO[0194] Found 0 must-gather tests                    
started: 0/1/4 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working validating webhook"

started: 0/2/4 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working mutating webhook"

started: 0/3/4 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working conversion webhook"


passed: (1m14s) 2025-10-14T07:32:03 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working mutating webhook"


passed: (1m36s) 2025-10-14T07:32:25 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working conversion webhook"


passed: (2m7s) 2025-10-14T07:32:57 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - parallel tests should have a working validating webhook"

started: 0/4/4 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - serial tests should be tolerant to tls secret deletion [Serial]"


passed: (1m4s) 2025-10-14T07:34:07 "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks - serial tests should be tolerant to tls secret deletion [Serial]"

Shutting down the monitor

```

Assisted-by: Claude Code