### PR TITLE
OCPBUGS-63347: Define Default timeouts and apply their usage accross to avoid flakes

### DIFF
--- a/openshift/tests-extension/pkg/helpers/catalogs.go
+++ b/openshift/tests-extension/pkg/helpers/catalogs.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/gomega"
@@ -48,5 +47,5 @@ func ExpectCatalogToBeServing(ctx context.Context, name string) {
 
 		g.Expect(meta.IsStatusConditionPresentAndEqual(conditions, olmv1.TypeServing, metav1.ConditionTrue)).
 			To(BeTrue(), fmt.Sprintf("catalog %q is not serving", name))
-	}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+	}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).Should(Succeed())
 }

--- a/openshift/tests-extension/pkg/helpers/cluster_catalog.go
+++ b/openshift/tests-extension/pkg/helpers/cluster_catalog.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -72,6 +71,6 @@ func EnsureCleanupClusterCatalog(ctx context.Context, name string) {
 	Eventually(func() bool {
 		err := k8s.Get(ctx, key, &olmv1.ClusterCatalog{})
 		return errors.IsNotFound(err)
-	}).WithTimeout(3*time.Minute).WithPolling(2*time.Second).
+	}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).
 		Should(BeTrue(), "ClusterCatalog %q failed to delete", name)
 }

--- a/openshift/tests-extension/pkg/helpers/cluster_extension.go
+++ b/openshift/tests-extension/pkg/helpers/cluster_extension.go
@@ -159,7 +159,7 @@ func ExpectClusterExtensionToBeInstalled(ctx context.Context, name string) {
 		installed := meta.FindStatusCondition(conditions, string(olmv1.TypeInstalled))
 		g.Expect(installed).ToNot(BeNil(), "Installed condition not found")
 		g.Expect(installed.Status).To(Equal(metav1.ConditionTrue), "Installed should be True")
-	}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+	}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).Should(Succeed())
 }
 
 // EnsureCleanupClusterExtension attempts to delete any ClusterExtension and a specified CRD
@@ -182,7 +182,7 @@ func EnsureCleanupClusterExtension(ctx context.Context, packageName, crdName str
 				Eventually(func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ce.Name}, &olmv1.ClusterExtension{})
 					return errors.IsNotFound(err)
-				}).WithTimeout(1*time.Minute).WithPolling(2*time.Second).Should(BeTrue(), "Cleanup ClusterExtension %s failed to delete", ce.Name)
+				}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).Should(BeTrue(), "Cleanup ClusterExtension %s failed to delete", ce.Name)
 			}
 		}
 	} else if !errors.IsNotFound(err) {
@@ -200,7 +200,7 @@ func EnsureCleanupClusterExtension(ctx context.Context, packageName, crdName str
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})
 				return errors.IsNotFound(err)
-			}).WithTimeout(1*time.Minute).WithPolling(2*time.Second).Should(BeTrue(), "Lingering CRD %s failed to delete", crdName)
+			}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).Should(BeTrue(), "Lingering CRD %s failed to delete", crdName)
 		} else if !errors.IsNotFound(err) {
 			fmt.Fprintf(GinkgoWriter, "Warning: Failed to get CRD %s during cleanup: %v\n", crdName, err)
 		}
@@ -214,7 +214,7 @@ func ExpectServiceAccountExists(ctx context.Context, name, namespace string) {
 	Eventually(func(g Gomega) {
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, sa)
 		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get ServiceAccount %q/%q: %v", namespace, name, err))
-	}).WithTimeout(5*time.Minute).WithPolling(3*time.Second).Should(Succeed(), "ServiceAccount %q/%q did not become visible within timeout", namespace, name)
+	}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).Should(Succeed(), "ServiceAccount %q/%q did not become visible within timeout", namespace, name)
 }
 
 // ExpectClusterRoleBindingExists waits for a ClusterRoleBinding to be available and visible to the client.
@@ -224,5 +224,5 @@ func ExpectClusterRoleBindingExists(ctx context.Context, name string) {
 	Eventually(func(g Gomega) {
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, crb)
 		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get ClusterRoleBinding %q: %v", name, err))
-	}).WithTimeout(10*time.Second).WithPolling(1*time.Second).Should(Succeed(), "ClusterRoleBinding %q did not become visible within timeout", name)
+	}).WithTimeout(2*time.Minute).WithPolling(DefaultPolling).Should(Succeed(), "ClusterRoleBinding %q did not become visible within timeout", name)
 }

--- a/openshift/tests-extension/pkg/helpers/defaults.go
+++ b/openshift/tests-extension/pkg/helpers/defaults.go
@@ -1,0 +1,19 @@
+package helpers
+
+import "time"
+
+// Default settings for tests that use Eventually.
+//
+// The timeout is long enough so slow CI systems don’t cause false failures.
+// This helps prevent sending wrong signals to Sippy and stops blocking
+// pull requests from merging in the whole OCP org.
+//
+// The polling interval controls how often we check again.
+// It’s set to a reasonable value to avoid too many API calls.
+const (
+	// DefaultTimeout is how long we wait before giving up on an Eventually check.
+	DefaultTimeout = 5 * time.Minute
+
+	// DefaultPolling is how often we check again during an Eventually test.
+	DefaultPolling = 3 * time.Second
+)

--- a/openshift/tests-extension/pkg/helpers/in_cluster_bundles.go
+++ b/openshift/tests-extension/pkg/helpers/in_cluster_bundles.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -316,7 +315,7 @@ func waitForBuildToFinish(ctx SpecContext, name, namespace string) {
 		}
 		g.Expect(cond).ToNot(BeNil())
 		g.Expect(cond.Status).To(Equal(corev1.ConditionTrue))
-	}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+	}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).Should(Succeed())
 
 	DeferCleanup(func() {
 		if CurrentSpecReport().Failed() {
@@ -338,7 +337,7 @@ func waitForClusterCatalogServing(ctx context.Context, name string) {
 		serving := meta.FindStatusCondition(cc.Status.Conditions, olmv1.TypeServing)
 		g.Expect(serving).ToNot(BeNil())
 		g.Expect(serving.Status).To(Equal(metav1.ConditionTrue))
-	}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+	}).WithTimeout(DefaultTimeout).WithPolling(DefaultPolling).Should(Succeed())
 }
 
 func startBuild(args ...string) *buildv1.Build {

--- a/openshift/tests-extension/test/olmv1-catalog.go
+++ b/openshift/tests-extension/test/olmv1-catalog.go
@@ -3,7 +3,6 @@ package test
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -99,7 +98,7 @@ func verifyCatalogEndpoint(ctx SpecContext, catalog, endpoint, query string) {
 				Fail(fmt.Sprintf("Job failed: %s", c.Message))
 			}
 		}
-	}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+	}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 }
 
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog", func() {
@@ -225,7 +224,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 			g.Expect(c.Status).To(Equal(metav1.ConditionTrue), "expected Progressing=True")
 			g.Expect(c.Reason).To(Equal("Retrying"), "expected reason to be 'Retrying'")
 			g.Expect(c.Message).To(ContainSubstring("error creating image source"), "expected image source error")
-		}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+		}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 	})
 })
 

--- a/openshift/tests-extension/test/olmv1-incompatible.go
+++ b/openshift/tests-extension/test/olmv1-incompatible.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -92,7 +91,7 @@ func waitForOlmUpgradeStatus(ctx SpecContext, status operatorv1.ConditionStatus,
 			g.Expect(cond.Reason).To(Equal(reasonIncompatibleOperatorsInstalled))
 			g.Expect(cond.Message).To(ContainSubstring(name))
 		}
-	}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+	}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 }
 
 func waitForClusterOperatorUpgradable(ctx SpecContext, name string) {
@@ -116,5 +115,5 @@ func waitForClusterOperatorUpgradable(ctx SpecContext, name string) {
 		g.Expect(cond.Status).To(Equal(configv1.ConditionFalse))
 		g.Expect(cond.Reason).To(Equal(reasonIncompatibleOperatorsInstalled))
 		g.Expect(cond.Message).To(ContainSubstring(name))
-	}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+	}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 }

--- a/openshift/tests-extension/test/olmv1-preflight.go
+++ b/openshift/tests-extension/test/olmv1-preflight.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -125,7 +124,7 @@ func runNegativePreflightTest(ctx context.Context, scenario int, namespace strin
 		c = meta.FindStatusCondition(latest.Status.Conditions, "Installed")
 		g.Expect(c).NotTo(BeNil())
 		g.Expect(c.Status).To(Equal(metav1.ConditionFalse))
-	}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+	}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 }
 
 // createDeficientClusterRole returns a modified ClusterRole according to the test scenario.

--- a/openshift/tests-extension/test/olmv1-singleownnamespace.go
+++ b/openshift/tests-extension/test/olmv1-singleownnamespace.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -458,7 +457,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 ope
 						}
 					}
 					g.Expect(found).To(BeTrue(), "failed to find deployment with olm.targetNamespaces annotation")
-				}).WithTimeout(5 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
+				}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 
 				By(fmt.Sprintf("cleaning up resources created for %s scenario to allow next scenario", sc.label))
 				deletePolicy := metav1.DeletePropagationForeground
@@ -602,7 +601,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace][Serial] O
 				g.Expect(installed).ToNot(BeNil(), "Installed condition not found")
 				g.Expect(installed.Status).To(Equal(metav1.ConditionFalse), "Installed should be False")
 				g.Expect(installed.Reason).To(Equal("Failed"))
-			}).WithTimeout(5 * time.Minute).WithPolling(1 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 		})
 })
 
@@ -742,6 +741,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 ope
 				g.Expect(installed.Status).To(Equal(metav1.ConditionFalse), "Installed should be False")
 				g.Expect(installed.Reason).To(Equal(olmv1.ReasonFailed))
 				g.Expect(installed.Message).ToNot(BeEmpty())
-			}).WithTimeout(5 * time.Minute).WithPolling(3 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 		})
 })

--- a/openshift/tests-extension/test/olmv1.go
+++ b/openshift/tests-extension/test/olmv1.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -185,7 +184,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation
 			ce := &olmv1.ClusterExtension{}
 			Eventually(func() error {
 				return env.Get().K8sClient.Get(ctx, client.ObjectKey{Name: name}, ce)
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 
 			By("waiting up to 2 minutes for ClusterExtension to report failure")
 			Eventually(func(g Gomega) {
@@ -204,6 +203,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation
 				g.Expect(installed.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(installed.Reason).To(Equal("Failed"))
 				g.Expect(installed.Message).To(Equal("No bundle installed"))
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 		})
 })

--- a/openshift/tests-extension/test/webhooks.go
+++ b/openshift/tests-extension/test/webhooks.go
@@ -126,7 +126,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 				default:
 					return fmt.Errorf("unexpected error: %v", err)
 				}
-			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 		})
 
 		It("should have a working mutating webhook [Serial]", Label("original-name:[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working mutating webhook"), func(ctx SpecContext) {
@@ -136,7 +136,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 			Eventually(func(g Gomega) {
 				_, err := dynamicClient.Resource(webhookTestV1).Namespace(webhookOperatorInstallNamespace).Create(ctx, resource, metav1.CreateOptions{})
 				g.Expect(err).ToNot(HaveOccurred())
-			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 
 			By("getting the created resource in v1 schema")
 			obj, err := dynamicClient.Resource(webhookTestV1).Namespace(webhookOperatorInstallNamespace).Get(ctx, mutatingWebhookResourceName, metav1.GetOptions{})
@@ -158,7 +158,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 			Eventually(func(g Gomega) {
 				_, err := dynamicClient.Resource(webhookTestV1).Namespace(webhookOperatorInstallNamespace).Create(ctx, resourceV1, metav1.CreateOptions{})
 				g.Expect(err).ToNot(HaveOccurred())
-			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 
 			By("getting the created resource in v2 schema")
 			obj, err := dynamicClient.Resource(webhookTestV2).Namespace(webhookOperatorInstallNamespace).Get(ctx, conversionWebhookResourceName, metav1.GetOptions{})
@@ -182,7 +182,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 				secret := &corev1.Secret{}
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: certificateSecretName, Namespace: webhookOperatorInstallNamespace}, secret)
 				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get secret %s/%s", webhookOperatorInstallNamespace, certificateSecretName))
-			}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 
 			By("checking webhook is responsive through secret recreation after manual deletion")
 			tlsSecret := &corev1.Secret{
@@ -224,7 +224,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 				}
 				g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service certificate secret %s/%s: %v", webhookOperatorInstallNamespace, certificateSecretName, err))
 				g.Expect(secret.Data).ToNot(BeEmpty(), "expected webhook service certificate secret data to not be empty after recreation")
-			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "webhook service certificate secret did not get recreated and populated within timeout")
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed(), "webhook service certificate secret did not get recreated and populated within timeout")
 
 			Eventually(func(g Gomega) {
 				resourceName := fmt.Sprintf("tls-deletion-test-%s", rand.String(5))
@@ -235,7 +235,7 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServi
 
 				err = dynamicClient.Resource(webhookTestV1).Namespace(webhookOperatorInstallNamespace).Delete(ctx, resource.GetName(), metav1.DeleteOptions{})
 				g.Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred(), fmt.Sprintf("failed to delete test resource %s: %v", resourceName, err))
-			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 		})
 	})
 
@@ -290,7 +290,7 @@ func setupWebhookOperator(ctx SpecContext, k8sClient client.Client, webhookOpera
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: webhookOperatorInstallNamespace}, tempNs)
 			g.Expect(client.IgnoreNotFound(err)).To(Succeed())
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "namespace still exists")
-		}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+		}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 	})
 
 	saName := fmt.Sprintf("%s-installer", webhookOperatorInstallNamespace)
@@ -335,7 +335,7 @@ func setupWebhookOperator(ctx SpecContext, k8sClient client.Client, webhookOpera
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: ce.Name}, tempCE)
 			g.Expect(client.IgnoreNotFound(err)).To(Succeed())
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ClusterExtension still exists")
-		}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+		}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed())
 	})
 
 	By("waiting for the webhook operator to be installed")
@@ -349,7 +349,7 @@ func setupWebhookOperator(ctx SpecContext, k8sClient client.Client, webhookOpera
 		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service %s/%s: %v", webhookOperatorInstallNamespace, serviceName, err))
 		g.Expect(svc.Spec.ClusterIP).ToNot(BeEmpty(), "expected webhook service to have a ClusterIP assigned")
 		g.Expect(svc.Spec.Ports).ToNot(BeEmpty(), "expected webhook service to have ports defined")
-	}).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "webhook service did not become ready within timeout")
+	}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed(), "webhook service did not become ready within timeout")
 
 	By("waiting for the webhook operator's service certificate secret to exist and be populated")
 	Eventually(func(g Gomega) {
@@ -365,7 +365,7 @@ func setupWebhookOperator(ctx SpecContext, k8sClient client.Client, webhookOpera
 		g.Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to get webhook service certificate secret %s/%s: %v",
 			webhookOperatorInstallNamespace, webhookServiceCert, err))
 		g.Expect(secret.Data).ToNot(BeEmpty(), "expected webhook service certificate secret data to not be empty")
-	}).WithTimeout(5*time.Minute).WithPolling(5*time.Second).Should(Succeed(), "webhook service certificate secret did not become available within timeout")
+	}).WithTimeout(helpers.DefaultTimeout).WithPolling(helpers.DefaultPolling).Should(Succeed(), "webhook service certificate secret did not become available within timeout")
 
 	By("setupWebhookOperator completed - ClusterExtension is ready for test to use")
 }


### PR DESCRIPTION
We need to use a generous timeout for these tests.
Some environments take a long time to start, and short timeouts can cause false failures.
These failures send bad signals to Sippy and, worse, can block other developers — since these tests run against every PR in the org.