### PR TITLE
OCPQE-30671:Add [OTP] to migrated tests-private cases Per ERT

### DIFF
--- a/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
+++ b/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
@@ -1,25 +1,11 @@
 [
   {
-    "name": "[sig-olmv1][Jira:OLM] clustercatalog PolarionID:69242-[Skipped:Disconnected]Catalogd deprecated package/bundlemetadata/catalogmetadata from clustercatalog CR",
-    "labels": {
-      "Extended": {},
-      "NonHyperShiftHOST": {}
-    },
-    "resources": {
-      "isolation": {}
-    },
-    "source": "openshift:payload:olmv1",
-    "lifecycle": "blocking",
-    "environmentSelector": {
-      "exclude": "topology==\"External\""
-    }
-  },
-  {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:83069-olmv1 static networkpolicy.",
+    "name": "[sig-olmv1][Jira:OLM] clustercatalog PolarionID:69242-[OTP][Skipped:Disconnected]Catalogd deprecated package bundlemetadata catalogmetadata from clustercatalog CR",
+    "originalName": "[sig-olmv1][Jira:OLM] clustercatalog PolarionID:69242-[Skipped:Disconnected]Catalogd deprecated package bundlemetadata catalogmetadata from clustercatalog CR",
     "labels": {
       "Extended": {},
       "NonHyperShiftHOST": {},
-      "ReleaseGate": {}
+      "original-name:[sig-olmv1][Jira:OLM] clustercatalog PolarionID:69242-[Skipped:Disconnected]Catalogd deprecated package bundlemetadata catalogmetadata from clustercatalog CR": {}
     },
     "resources": {
       "isolation": {}
@@ -31,10 +17,13 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:68936-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:83069-[OTP]olmv1 static networkpolicy.",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:83069-olmv1 static networkpolicy.",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "ReleaseGate": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:83069-olmv1 static networkpolicy.": {}
     },
     "resources": {
       "isolation": {}
@@ -46,10 +35,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:68937-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand rbac object",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:68936-[OTP][Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:68936-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:68936-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand": {}
     },
     "resources": {
       "isolation": {}
@@ -61,11 +52,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:75492-[Skipped:Disconnected]cluster extension can not be installed with wrong sa or insufficient permission sa",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:68937-[OTP][Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand rbac object",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:68937-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand rbac object",
     "labels": {
       "Extended": {},
-      "LEVEL0": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:68937-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand rbac object": {}
     },
     "resources": {
       "isolation": {}
@@ -77,11 +69,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:75493-[Skipped:Disconnected]cluster extension can be installed with enough permission sa",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:75492-[OTP][Level0][Skipped:Disconnected]cluster extension can not be installed with wrong sa or insufficient permission sa",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:75492-[Skipped:Disconnected]cluster extension can not be installed with wrong sa or insufficient permission sa",
     "labels": {
       "Extended": {},
-      "LEVEL0": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:75492-[Skipped:Disconnected]cluster extension can not be installed with wrong sa or insufficient permission sa": {}
     },
     "resources": {
       "isolation": {}
@@ -93,10 +86,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81538-[Skipped:Disconnected]preflight check on permission on allns mode",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:75493-[OTP][Level0][Skipped:Disconnected]cluster extension can be installed with enough permission sa",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:75493-[Skipped:Disconnected]cluster extension can be installed with enough permission sa",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:75493-[Skipped:Disconnected]cluster extension can be installed with enough permission sa": {}
     },
     "resources": {
       "isolation": {}
@@ -108,10 +103,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81664-[Skipped:Disconnected]preflight check on permission on own ns mode",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81538-[OTP][Skipped:Disconnected]preflight check on permission on allns mode",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81538-[Skipped:Disconnected]preflight check on permission on allns mode",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:81538-[Skipped:Disconnected]preflight check on permission on allns mode": {}
     },
     "resources": {
       "isolation": {}
@@ -123,10 +120,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81696-[Skipped:Disconnected]preflight check on permission on single ns mode",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81664-[OTP][Skipped:Disconnected]preflight check on permission on own ns mode",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81664-[Skipped:Disconnected]preflight check on permission on own ns mode",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:81664-[Skipped:Disconnected]preflight check on permission on own ns mode": {}
     },
     "resources": {
       "isolation": {}
@@ -138,10 +137,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:74618-[Skipped:Disconnected]ClusterExtension supports simple registry vzero bundles only",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81696-[OTP][Skipped:Disconnected]preflight check on permission on single ns mode",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:81696-[Skipped:Disconnected]preflight check on permission on single ns mode",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:81696-[Skipped:Disconnected]preflight check on permission on single ns mode": {}
     },
     "resources": {
       "isolation": {}
@@ -153,10 +154,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76843-[Skipped:Disconnected]support disc with icsp[Timeout:30m] [Serial][Disruptive][Slow]",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:74618-[OTP][Skipped:Disconnected]ClusterExtension supports simple registry vzero bundles only",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:74618-[Skipped:Disconnected]ClusterExtension supports simple registry vzero bundles only",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:74618-[Skipped:Disconnected]ClusterExtension supports simple registry vzero bundles only": {}
     },
     "resources": {
       "isolation": {}
@@ -168,10 +171,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76844-[Skipped:Disconnected]support disc with itms and idms[Timeout:30m] [Serial][Disruptive][Slow]",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76843-[OTP][Skipped:Disconnected]support disc with icsp[Timeout:30m] [Serial][Disruptive][Slow]",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76843-[Skipped:Disconnected]support disc with icsp[Timeout:30m] [Serial][Disruptive][Slow]",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76843-[Skipped:Disconnected]support disc with icsp[Timeout:30m] [Serial][Disruptive][Slow]": {}
     },
     "resources": {
       "isolation": {}
@@ -183,10 +188,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:78193-[Skipped:Disconnected]Runtime validation of container images using sigstore signatures [Serial][Disruptive][Slow]",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76844-[OTP][Skipped:Disconnected]support disc with itms and idms[Timeout:30m] [Serial][Disruptive][Slow]",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76844-[Skipped:Disconnected]support disc with itms and idms[Timeout:30m] [Serial][Disruptive][Slow]",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76844-[Skipped:Disconnected]support disc with itms and idms[Timeout:30m] [Serial][Disruptive][Slow]": {}
     },
     "resources": {
       "isolation": {}
@@ -198,10 +205,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:78300-[Skipped:Disconnected]validation of container images using sigstore signatures with different policy [Serial][Disruptive][Slow]",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:78193-[OTP][Skipped:Disconnected]Runtime validation of container images using sigstore signatures [Serial][Disruptive][Slow]",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:78193-[Skipped:Disconnected]Runtime validation of container images using sigstore signatures [Serial][Disruptive][Slow]",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:78193-[Skipped:Disconnected]Runtime validation of container images using sigstore signatures [Serial][Disruptive][Slow]": {}
     },
     "resources": {
       "isolation": {}
@@ -213,10 +222,12 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76983-[Skipped:Disconnected]install index and bundle from private image[Slow]",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:78300-[OTP][Skipped:Disconnected]validation of container images using sigstore signatures with different policy [Serial][Disruptive][Slow]",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:78300-[Skipped:Disconnected]validation of container images using sigstore signatures with different policy [Serial][Disruptive][Slow]",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:78300-[Skipped:Disconnected]validation of container images using sigstore signatures with different policy [Serial][Disruptive][Slow]": {}
     },
     "resources": {
       "isolation": {}
@@ -228,10 +239,29 @@
     }
   },
   {
-    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76985-[Skipped:Disconnected]authfile is updated automatically[Timeout:30m] [Serial][Disruptive][Slow]",
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76983-[OTP][Skipped:Disconnected]install index and bundle from private image[Slow]",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76983-[Skipped:Disconnected]install index and bundle from private image[Slow]",
     "labels": {
       "Extended": {},
-      "NonHyperShiftHOST": {}
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76983-[Skipped:Disconnected]install index and bundle from private image[Slow]": {}
+    },
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {
+      "exclude": "topology==\"External\""
+    }
+  },
+  {
+    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76985-[OTP][Skipped:Disconnected]authfile is updated automatically[Timeout:30m] [Serial][Disruptive][Slow]",
+    "originalName": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:76985-[Skipped:Disconnected]authfile is updated automatically[Timeout:30m] [Serial][Disruptive][Slow]",
+    "labels": {
+      "Extended": {},
+      "NonHyperShiftHOST": {},
+      "original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76985-[Skipped:Disconnected]authfile is updated automatically[Timeout:30m] [Serial][Disruptive][Slow]": {}
     },
     "resources": {
       "isolation": {}

--- a/openshift/tests-extension/test/qe/README.md
+++ b/openshift/tests-extension/test/qe/README.md
@@ -36,7 +36,6 @@ We need to identify all cases from tests-private among all cases, then mark whic
    g.It("xxxxxx", g.Label("ReleaseGate"), func() {
    ```
    - This makes the case equivalent to origin cases for openshift-tests
-   - Test framework automatically sets these cases without `ReleaseGate` as `Informing`
    - For the cases with `ReleaseGate` that need `Informing`, add:
      ```go
      import oteg "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
@@ -161,6 +160,8 @@ We need to identify all cases from tests-private among all cases, then mark whic
 
 ## Test Case Migration Guide
 
+**Required For all QE cases**: Do not use `&|!,()/` in case title
+
 ### A. Code Changes for Migrated Cases
 
 All migrated test case code needs the following changes to run in the new test framework:
@@ -180,32 +181,33 @@ All migrated test case code needs the following changes to run in the new test f
 2. **Jira Component**: Add `[Jira:OLM]` in case title
 3. **OpenShift CI compatibility**: If you believe the case meets OpenShift CI requirements, add `ReleaseGate` label to Ginkgo
    - **Note**: Don't add `ReleaseGate` if case title contains `Disruptive` or `Slow`, or labels contain `StressTest`
+4. **Required For Migrated case from test-private**: Add `[OTP]` in case title
 
 #### Optional Label for Migration and New
-4. **LEVEL0**: Use Ginkgo label `g.Label("LEVEL0")`
-5. **Author**: Deprecated
-6. **ConnectedOnly**: Add `[Skipped:Disconnected]` in title
-7. **DisconnectedOnly**: Add `[Skipped:Connected][Skipped:Proxy]` in title
-8. **Case ID**: change to `PolarionID:xxxxxx`
-9. **Importance**: Deprecated
-10. **NonPrerelease**: Deprecated
+1. **LEVEL0**: Use title label `[Level0]`
+2. **Author**: Deprecated
+3. **ConnectedOnly**: Add `[Skipped:Disconnected]` in title
+4. **DisconnectedOnly**: Add `[Skipped:Connected][Skipped:Proxy]` in title
+5. **Case ID**: change to `PolarionID:xxxxxx`
+6. **Importance**: Deprecated
+7. **NonPrerelease**: Deprecated
     - **Longduration**: Change to `[Slow]` in case title
     - **ChkUpg**: Not supported (openshift-tests upgrade differs from OpenShift QE)
-11. **VMonly**: Deprecated
-12. **Slow, Serial, Disruptive**: Preserved
-13. **DEPRECATED**: Deprecated, corresponding cases deprecated. Use `IgnoreObsoleteTests` for deprecation after addition
-14. **CPaasrunOnly, CPaasrunBoth, StagerunOnly, StagerunBoth, ProdrunOnly, ProdrunBoth**: Deprecated
-15. **StressTest**: Use Ginkgo label `g.Label("StressTest")`
-16. **NonHyperShiftHOST**: Use Ginkgo label `g.Label("NonHyperShiftHOST")` or use `IsHypershiftHostedCluster` judgment, then skip
-17. **HyperShiftMGMT**: Deprecated. For cases needing hypershift mgmt execution, use `g.Label("NonHyperShiftHOST")` and `ValidHypershiftAndGetGuestKubeConf` validation (to be provided when OLMv1 supports hypershift)
-18. **MicroShiftOnly**: Deprecated. For cases not supporting microshift, use `SkipMicroshift` judgment, then skip
-19. **ROSA**: Deprecated. Three ROSA job types:
+8. **VMonly**: Deprecated
+9. **Slow, Serial, Disruptive**: Preserved
+10. **DEPRECATED**: Deprecated, corresponding cases deprecated. Use `IgnoreObsoleteTests` for deprecation after addition
+11. **CPaasrunOnly, CPaasrunBoth, StagerunOnly, StagerunBoth, ProdrunOnly, ProdrunBoth**: Deprecated
+12. **StressTest**: Use Ginkgo label `g.Label("StressTest")`
+13. **NonHyperShiftHOST**: Use Ginkgo label `g.Label("NonHyperShiftHOST")` or use `IsHypershiftHostedCluster` judgment, then skip
+14. **HyperShiftMGMT**: Deprecated. For cases needing hypershift mgmt execution, use `g.Label("NonHyperShiftHOST")` and `ValidHypershiftAndGetGuestKubeConf` validation (to be provided when OLMv1 supports hypershift)
+15. **MicroShiftOnly**: Deprecated. For cases not supporting microshift, use `SkipMicroshift` judgment, then skip
+16. **ROSA**: Deprecated. Three ROSA job types:
     - `rosa-sts-ovn`: equivalent to OCP
     - `rosa-sts-hypershift-ovn`: equivalent to hypershift hosted
     - `rosa-classic-sts`: doesn't use openshift-tests
-20. **ARO**: Deprecated. All ARO jobs based on HCP are equivalent to hypershift hosted (don't actually use openshift-test)
-21. **OSD_CCS**: Deprecated. Only one job type: `osd-ccs-gcp` equivalent to OCP
-22. **Feature Gates**: Handle test cases based on their feature gate requirements:
+17. **ARO**: Deprecated. All ARO jobs based on HCP are equivalent to hypershift hosted (don't actually use openshift-test)
+18. **OSD_CCS**: Deprecated. Only one job type: `osd-ccs-gcp` equivalent to OCP
+19. **Feature Gates**: Handle test cases based on their feature gate requirements:
 
     **Case 1: Test only runs when feature gate is enabled**
     - The test should not execute if the feature gate is disabled
@@ -223,6 +225,7 @@ All migrated test case code needs the following changes to run in the new test f
     - The test executes the same way regardless of feature gate status
     - Do NOT use `IsFeaturegateEnabled` check
     - Do NOT add `[OCPFeatureGate:xxxx]` label
+20. **Exclusive**: change to `Serial`
 
 ## Test Automation Code Requirements
 

--- a/openshift/tests-extension/test/qe/specs/olmv1_cc.go
+++ b/openshift/tests-extension/test/qe/specs/olmv1_cc.go
@@ -21,7 +21,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clustercatalog", g.Label("NonHyperShif
 		exutil.SkipNoOLMv1Core(oc)
 	})
 
-	g.It("PolarionID:69242-[Skipped:Disconnected]Catalogd deprecated package/bundlemetadata/catalogmetadata from clustercatalog CR", func() {
+	g.It("PolarionID:69242-[OTP][Skipped:Disconnected]Catalogd deprecated package bundlemetadata catalogmetadata from clustercatalog CR", g.Label("original-name:[sig-olmv1][Jira:OLM] clustercatalog PolarionID:69242-[Skipped:Disconnected]Catalogd deprecated package bundlemetadata catalogmetadata from clustercatalog CR"), func() {
 		g.By("get the old related crd package/bundlemetadata/bundledeployment")
 		crds, err := oc.WithoutNamespace().AsAdmin().Run("get").Args("crd").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/openshift/tests-extension/test/qe/specs/olmv1_ce.go
+++ b/openshift/tests-extension/test/qe/specs/olmv1_ce.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 		exutil.SkipNoOLMv1Core(oc)
 	})
 
-	g.It("PolarionID:83069-olmv1 static networkpolicy.", g.Label("ReleaseGate"), func() {
+	g.It("PolarionID:83069-[OTP]olmv1 static networkpolicy.", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:83069-olmv1 static networkpolicy."), g.Label("ReleaseGate"), func() {
 		policies := []olmv1util.NpExpecter{
 			{
 				Name:      "catalogd-controller-manager",
@@ -159,7 +159,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:68936-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand", func() {
+	g.It("PolarionID:68936-[OTP][Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:68936-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand"), func() {
 		e2e.Logf("Testing ClusterExtension installation failure when ServiceAccount lacks sufficient permissions for operand resources. Originally case 75492, using 68936 for faster execution.")
 		exutil.SkipForSNOCluster(oc)
 		var (
@@ -227,7 +227,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:68937-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand rbac object", func() {
+	g.It("PolarionID:68937-[OTP][Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand rbac object", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:68937-[Skipped:Disconnected]cluster extension can not be installed with insufficient permission sa for operand rbac object"), func() {
 		e2e.Logf("Testing ClusterExtension installation failure when ServiceAccount lacks sufficient permissions for operand RBAC objects. Originally case 75492, using 68937 for faster execution.")
 		exutil.SkipForSNOCluster(oc)
 		var (
@@ -295,7 +295,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:75492-[Skipped:Disconnected]cluster extension can not be installed with wrong sa or insufficient permission sa", g.Label("LEVEL0"), func() {
+	g.It("PolarionID:75492-[OTP][Level0][Skipped:Disconnected]cluster extension can not be installed with wrong sa or insufficient permission sa", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:75492-[Skipped:Disconnected]cluster extension can not be installed with wrong sa or insufficient permission sa"), func() {
 		exutil.SkipForSNOCluster(oc)
 		var (
 			caseID                       = "75492"
@@ -382,7 +382,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 		ce75492WrongSa.CheckClusterExtensionCondition(oc, "Installed", "message", "not found", 10, 60, 0)
 	})
 
-	g.It("PolarionID:75493-[Skipped:Disconnected]cluster extension can be installed with enough permission sa", g.Label("LEVEL0"), func() {
+	g.It("PolarionID:75493-[OTP][Level0][Skipped:Disconnected]cluster extension can be installed with enough permission sa", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:75493-[Skipped:Disconnected]cluster extension can be installed with enough permission sa"), func() {
 		exutil.SkipForSNOCluster(oc)
 		var (
 			caseID                       = "75493"
@@ -454,7 +454,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 		o.Expect(olmv1util.Appearance(oc, exutil.Disappear, "services", "nginx-ok-v3283-75493-controller-manager-metrics-service", "-n", ns)).To(o.BeTrue())
 	})
 
-	g.It("PolarionID:81538-[Skipped:Disconnected]preflight check on permission on allns mode", func() {
+	g.It("PolarionID:81538-[OTP][Skipped:Disconnected]preflight check on permission on allns mode", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:81538-[Skipped:Disconnected]preflight check on permission on allns mode"), func() {
 		if !olmv1util.IsFeaturegateEnabled(oc, "NewOLMPreflightPermissionChecks") {
 			g.Skip("NewOLMPreflightPermissionChecks feature gate is disabled. This test requires preflight permission validation to be enabled.")
 		}
@@ -567,7 +567,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 		ce.CheckClusterExtensionCondition(oc, "Progressing", "reason", "Succeeded", 10, 600, 0)
 	})
 
-	g.It("PolarionID:81664-[Skipped:Disconnected]preflight check on permission on own ns mode", func() {
+	g.It("PolarionID:81664-[OTP][Skipped:Disconnected]preflight check on permission on own ns mode", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:81664-[Skipped:Disconnected]preflight check on permission on own ns mode"), func() {
 		if !olmv1util.IsFeaturegateEnabled(oc, "NewOLMPreflightPermissionChecks") ||
 			!olmv1util.IsFeaturegateEnabled(oc, "NewOLMOwnSingleNamespace") {
 			g.Skip("Required feature gates are disabled: NewOLMPreflightPermissionChecks and NewOLMOwnSingleNamespace must both be enabled for this test.")
@@ -676,7 +676,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 		ce.Create(oc)
 	})
 
-	g.It("PolarionID:81696-[Skipped:Disconnected]preflight check on permission on single ns mode", func() {
+	g.It("PolarionID:81696-[OTP][Skipped:Disconnected]preflight check on permission on single ns mode", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:81696-[Skipped:Disconnected]preflight check on permission on single ns mode"), func() {
 		if !olmv1util.IsFeaturegateEnabled(oc, "NewOLMPreflightPermissionChecks") ||
 			!olmv1util.IsFeaturegateEnabled(oc, "NewOLMOwnSingleNamespace") {
 			g.Skip("Required feature gates are disabled: NewOLMPreflightPermissionChecks and NewOLMOwnSingleNamespace must both be enabled for this test.")
@@ -809,7 +809,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 		ce.Create(oc)
 	})
 
-	g.It("PolarionID:74618-[Skipped:Disconnected]ClusterExtension supports simple registry vzero bundles only", func() {
+	g.It("PolarionID:74618-[OTP][Skipped:Disconnected]ClusterExtension supports simple registry vzero bundles only", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:74618-[Skipped:Disconnected]ClusterExtension supports simple registry vzero bundles only"), func() {
 		exutil.SkipForSNOCluster(oc)
 		var (
 			ns                           = "ns-74618"
@@ -931,7 +931,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:76843-[Skipped:Disconnected]support disc with icsp[Timeout:30m] [Disruptive][Slow]", func() {
+	g.It("PolarionID:76843-[OTP][Skipped:Disconnected]support disc with icsp[Timeout:30m] [Disruptive][Slow]", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76843-[Skipped:Disconnected]support disc with icsp[Timeout:30m] [Serial][Disruptive][Slow]"), func() {
 		exutil.SkipForSNOCluster(oc)
 		var (
 			caseID                       = "76843"
@@ -1012,7 +1012,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:76844-[Skipped:Disconnected]support disc with itms and idms[Timeout:30m] [Disruptive][Slow]", func() {
+	g.It("PolarionID:76844-[OTP][Skipped:Disconnected]support disc with itms and idms[Timeout:30m] [Disruptive][Slow]", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76844-[Skipped:Disconnected]support disc with itms and idms[Timeout:30m] [Serial][Disruptive][Slow]"), func() {
 		exutil.SkipOnProxyCluster(oc)
 		exutil.SkipForSNOCluster(oc)
 		var (
@@ -1094,7 +1094,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:78193-[Skipped:Disconnected]Runtime validation of container images using sigstore signatures [Disruptive][Slow]", func() {
+	g.It("PolarionID:78193-[OTP][Skipped:Disconnected]Runtime validation of container images using sigstore signatures [Disruptive][Slow]", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:78193-[Skipped:Disconnected]Runtime validation of container images using sigstore signatures [Serial][Disruptive][Slow]"), func() {
 		if !exutil.CheckAppearance(oc, 1*time.Second, 1*time.Second, exutil.Immediately,
 			exutil.AsAdmin, exutil.WithoutNamespace, exutil.Appear, "crd", "clusterimagepolicies.config.openshift.io") {
 			g.Skip("ClusterImagePolicy CRD not found. This test requires sigstore signature validation capabilities.")
@@ -1185,7 +1185,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:78300-[Skipped:Disconnected]validation of container images using sigstore signatures with different policy [Disruptive][Slow]", func() {
+	g.It("PolarionID:78300-[OTP][Skipped:Disconnected]validation of container images using sigstore signatures with different policy [Disruptive][Slow]", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:78300-[Skipped:Disconnected]validation of container images using sigstore signatures with different policy [Serial][Disruptive][Slow]"), func() {
 		if !exutil.CheckAppearance(oc, 1*time.Second, 1*time.Second, exutil.Immediately,
 			exutil.AsAdmin, exutil.WithoutNamespace, exutil.Appear, "crd", "clusterimagepolicies.config.openshift.io") {
 			g.Skip("ClusterImagePolicy CRD not found. This test requires sigstore signature validation capabilities.")
@@ -1267,7 +1267,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:76983-[Skipped:Disconnected]install index and bundle from private image[Slow]", func() {
+	g.It("PolarionID:76983-[OTP][Skipped:Disconnected]install index and bundle from private image[Slow]", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76983-[Skipped:Disconnected]install index and bundle from private image[Slow]"), func() {
 		exutil.SkipForSNOCluster(oc)
 		// This test validates installation from private container images and depends on cluster-wide pull secrets
 		var (
@@ -1340,7 +1340,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 
 	})
 
-	g.It("PolarionID:76985-[Skipped:Disconnected]authfile is updated automatically[Timeout:30m] [Disruptive][Slow]", func() {
+	g.It("PolarionID:76985-[OTP][Skipped:Disconnected]authfile is updated automatically[Timeout:30m] [Disruptive][Slow]", g.Label("original-name:[sig-olmv1][Jira:OLM] clusterextension PolarionID:76985-[Skipped:Disconnected]authfile is updated automatically[Timeout:30m] [Serial][Disruptive][Slow]"), func() {
 		exutil.SkipForSNOCluster(oc)
 		var (
 			caseID = "76985"


### PR DESCRIPTION
  # Add [OTP] Tags to Migrated Tests-Private Test Cases

  ## Why / Problem Statement

  The ERT team requires all OLMv1 test cases migrated from openshift-tests-private to be tagged with `[OTP]` labels for proper test categorization and execution.  Additionally, the OTE framework requires `original-name` Ginkgo labels when renaming tests to maintain test history tracking.

  ## What / Solution

This PR adds `[OTP]` tags to all OLMv1 migrated test case titles and implements proper test name tracking via `original-name` labels as required by the OTE framework.


**Key Points**:
- `[OTP]` tag inserted immediately after PolarionID
-  Please follow [README](https://github.com/openshift/operator-framework-operator-controller/blob/main/openshift/tests-extension/test/qe/README.md#how-to-keep-test-names-unique) to keep test name unique.

Note:
1, LEVEL0 ginkgo label change to title label [Level0]
2, Please Do not use `&|!,()/` in case title for possible ginkgo label.

 Assisted-by: Claude Code

/cc @jianzhangbjz @Xia-Zhao-rh @bandrade 