### PR TITLE
OPRUN-4252: fix(OTE): fix OpenShift Kubernetes replace version format

### DIFF
--- a/openshift/tests-extension/README.md
+++ b/openshift/tests-extension/README.md
@@ -295,3 +295,20 @@ More information:
 
 For help with the OpenShift Tests Extension (OTE), you can:
 #wg-openshift-tests-extension
+
+### How to update the go.mod/go.sum files with replaces?
+
+To get the latest replaces for ocp/* modules, run the following command:
+
+```shell
+$ ./hack/ocp-replace.sh 
+Discovering latest OCP commit from https://github.com/openshift/kubernetes.git…
+Resolving pseudo-version for k8s.io/kubernetes@891f5bb0306166d5625b89fc8dc86bbc8c85f549…
+Resolved OCP version: v0.0.0-20251108023427-891f5bb03061
+Updating go.mod replaces…
+
+Done.
+  OCP commit:  891f5bb0306166d5625b89fc8dc86bbc8c85f549
+  OCP version: v0.0.0-20251108023427-891f5bb03061
+go.mod and go.sum vendor/ updated.
+```

--- a/openshift/tests-extension/go.mod
+++ b/openshift/tests-extension/go.mod
@@ -118,39 +118,66 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-// This replace replace is required for we use the OCP fork of Ginkgo.
-replace (
-	github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20250416174521-4eb003743b54
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
-	k8s.io/api => github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20251108023427-891f5bb03061
-	k8s.io/apiextensions-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20251108023427-891f5bb03061
-	k8s.io/apimachinery => github.com/openshift/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20251108023427-891f5bb03061
-	k8s.io/apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20251108023427-891f5bb03061
-	k8s.io/cli-runtime => github.com/openshift/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20251108023427-891f5bb03061
-	k8s.io/client-go => github.com/openshift/kubernetes/staging/src/k8s.io/client-go v0.0.0-20251108023427-891f5bb03061
-	k8s.io/cloud-provider => github.com/openshift/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20251108023427-891f5bb03061
-	k8s.io/cluster-bootstrap => github.com/openshift/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20251108023427-891f5bb03061
-	k8s.io/code-generator => github.com/openshift/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20251108023427-891f5bb03061
-	k8s.io/component-base => github.com/openshift/kubernetes/staging/src/k8s.io/component-base v0.0.0-20251108023427-891f5bb03061
-	k8s.io/component-helpers => github.com/openshift/kubernetes/staging/src/k8s.io/component-helpers v0.0.0-20251108023427-891f5bb03061
-	k8s.io/controller-manager => github.com/openshift/kubernetes/staging/src/k8s.io/controller-manager v0.0.0-20251108023427-891f5bb03061
-	k8s.io/cri-api => github.com/openshift/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20251108023427-891f5bb03061
-	k8s.io/cri-client => github.com/openshift/kubernetes/staging/src/k8s.io/cri-client v0.0.0-20251108023427-891f5bb03061
-	k8s.io/csi-translation-lib => github.com/openshift/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20251108023427-891f5bb03061
-	k8s.io/dynamic-resource-allocation => github.com/openshift/kubernetes/staging/src/k8s.io/dynamic-resource-allocation v0.0.0-20251108023427-891f5bb03061
-	k8s.io/endpointslice => github.com/openshift/kubernetes/staging/src/k8s.io/endpointslice v0.0.0-20251108023427-891f5bb03061
-	k8s.io/externaljwt => github.com/openshift/kubernetes/staging/src/k8s.io/externaljwt v0.0.0-20251108023427-891f5bb03061
-	k8s.io/kube-aggregator => github.com/openshift/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20251108023427-891f5bb03061
-	k8s.io/kube-controller-manager => github.com/openshift/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20251108023427-891f5bb03061
-	k8s.io/kube-proxy => github.com/openshift/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20251108023427-891f5bb03061
-	k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20251108023427-891f5bb03061
-	k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20251108023427-891f5bb03061
-	k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20251108023427-891f5bb03061
-	k8s.io/kubernetes => github.com/openshift/kubernetes v1.30.1-0.20251108023427-891f5bb03061
-	k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20251108023427-891f5bb03061
-	k8s.io/mount-utils => github.com/openshift/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20251108023427-891f5bb03061
-	k8s.io/pod-security-admission => github.com/openshift/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20251108023427-891f5bb03061
-	k8s.io/sample-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20251108023427-891f5bb03061
-	k8s.io/sample-cli-plugin => github.com/openshift/kubernetes/staging/src/k8s.io/sample-cli-plugin v0.0.0-20251108023427-891f5bb03061
-	k8s.io/sample-controller => github.com/openshift/kubernetes/staging/src/k8s.io/sample-controller v0.0.0-20251108023427-891f5bb03061
-)
+replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20250416174521-4eb003743b54
+
+replace k8s.io/kubernetes => github.com/openshift/kubernetes v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/api => github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/apiextensions-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/apimachinery => github.com/openshift/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/cli-runtime => github.com/openshift/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/client-go => github.com/openshift/kubernetes/staging/src/k8s.io/client-go v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/cloud-provider => github.com/openshift/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/cluster-bootstrap => github.com/openshift/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/code-generator => github.com/openshift/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/component-base => github.com/openshift/kubernetes/staging/src/k8s.io/component-base v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/component-helpers => github.com/openshift/kubernetes/staging/src/k8s.io/component-helpers v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/controller-manager => github.com/openshift/kubernetes/staging/src/k8s.io/controller-manager v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/cri-api => github.com/openshift/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/cri-client => github.com/openshift/kubernetes/staging/src/k8s.io/cri-client v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/csi-translation-lib => github.com/openshift/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/dynamic-resource-allocation => github.com/openshift/kubernetes/staging/src/k8s.io/dynamic-resource-allocation v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/endpointslice => github.com/openshift/kubernetes/staging/src/k8s.io/endpointslice v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/externaljwt => github.com/openshift/kubernetes/staging/src/k8s.io/externaljwt v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/kube-aggregator => github.com/openshift/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/kube-controller-manager => github.com/openshift/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/kube-proxy => github.com/openshift/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/mount-utils => github.com/openshift/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/pod-security-admission => github.com/openshift/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/sample-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/sample-cli-plugin => github.com/openshift/kubernetes/staging/src/k8s.io/sample-cli-plugin v0.0.0-20251108023427-891f5bb03061
+
+replace k8s.io/sample-controller => github.com/openshift/kubernetes/staging/src/k8s.io/sample-controller v0.0.0-20251108023427-891f5bb03061

--- a/openshift/tests-extension/go.sum
+++ b/openshift/tests-extension/go.sum
@@ -106,8 +106,8 @@ github.com/openshift/api v0.0.0-20251106190826-ebe535b08719 h1:KEwYyKaJniwhoyLB7
 github.com/openshift/api v0.0.0-20251106190826-ebe535b08719/go.mod h1:d5uzF0YN2nQQFA0jIEWzzOZ+edmo6wzlGLvx5Fhz4uY=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 h1:9JBeIXmnHlpXTQPi7LPmu1jdxznBhAE7bb1K+3D8gxY=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235/go.mod h1:L49W6pfrZkfOE5iC1PqEkuLkXG4W0BX4w8b+L2Bv7fM=
-github.com/openshift/kubernetes v1.30.1-0.20251108023427-891f5bb03061 h1:kWubu+TA/SlhC4WicaEOVgrZbInY/fI73T68LxcocJY=
-github.com/openshift/kubernetes v1.30.1-0.20251108023427-891f5bb03061/go.mod h1:w3+IfrXNp5RosdDXg3LB55yijJqR/FwouvVntYHQf0o=
+github.com/openshift/kubernetes v0.0.0-20251108023427-891f5bb03061 h1:XVgudZfcjtF8UPIUarXXu6z7tZJLxrenIXOaB8e0tRk=
+github.com/openshift/kubernetes v0.0.0-20251108023427-891f5bb03061/go.mod h1:w3+IfrXNp5RosdDXg3LB55yijJqR/FwouvVntYHQf0o=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20251108023427-891f5bb03061 h1:uE4i/OdgU+YypcJ7vc8abZJQRyd6zwnUpY9nSdBAHEs=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20251108023427-891f5bb03061/go.mod h1:sRDdfB9W3pU52PnpjJ9RuMVsg/UQ5iLNlVfbRpb250o=
 github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20251108023427-891f5bb03061 h1:IMHDnaXsxNDz4MCgmj6F5odsJgypLWPaLYtVtiI6tsI=

--- a/openshift/tests-extension/hack/ocp-replace.sh
+++ b/openshift/tests-extension/hack/ocp-replace.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update go.mod replaces to the latest (or provided) OpenShift Kubernetes fork commit.
+# Usage:
+#   ./ocp-replace-exact.sh                # uses latest commit on OCP fork default branch
+#   ./ocp-replace-exact.sh <commitSHA>    # uses specific commit
+
+OCP_REPO="github.com/openshift/kubernetes"
+OCP_REMOTE="https://github.com/openshift/kubernetes.git"
+
+# OCP Ginkgo fork pin (as in your go.mod)
+GINKGO_FORK="github.com/openshift/onsi-ginkgo/v2"
+GINKGO_VERSION="v2.6.1-0.20250416174521-4eb003743b54"
+
+# EXACT list you provided (all are staging modules EXCEPT the root "k8s.io/kubernetes").
+STAGING_MODULES=(
+  k8s.io/api
+  k8s.io/apiextensions-apiserver
+  k8s.io/apimachinery
+  k8s.io/apiserver
+  k8s.io/cli-runtime
+  k8s.io/client-go
+  k8s.io/cloud-provider
+  k8s.io/cluster-bootstrap
+  k8s.io/code-generator
+  k8s.io/component-base
+  k8s.io/component-helpers
+  k8s.io/controller-manager
+  k8s.io/cri-api
+  k8s.io/cri-client
+  k8s.io/csi-translation-lib
+  k8s.io/dynamic-resource-allocation
+  k8s.io/endpointslice
+  k8s.io/externaljwt
+  k8s.io/kube-aggregator
+  k8s.io/kube-controller-manager
+  k8s.io/kube-proxy
+  k8s.io/kube-scheduler
+  k8s.io/kubectl
+  k8s.io/kubelet
+  k8s.io/metrics
+  k8s.io/mount-utils
+  k8s.io/pod-security-admission
+  k8s.io/sample-apiserver
+  k8s.io/sample-cli-plugin
+  k8s.io/sample-controller
+)
+
+die(){ echo "error: $*" >&2; exit 1; }
+need(){ command -v "$1" >/dev/null 2>&1 || die "missing command: $1"; }
+
+need go
+need git
+[[ -f go.mod ]] || die "go.mod not found; run this from your repository root"
+
+# Accept a commit SHA or use latest on default branch.
+OCP_COMMIT="${1:-}"
+if [[ -z "$OCP_COMMIT" ]]; then
+  echo "Discovering latest OCP commit from ${OCP_REMOTE}…"
+  OCP_COMMIT="$(git ls-remote "$OCP_REMOTE" HEAD | awk '{print $1}')"
+  [[ -n "$OCP_COMMIT" ]] || die "failed to discover latest commit from $OCP_REMOTE"
+else
+  echo "Using provided OCP commit: ${OCP_COMMIT}"
+fi
+
+# Resolve canonical pseudo-version (v0.0.0-YYYYMMDDHHMMSS-<sha>) for that commit.
+# The module declares itself as k8s.io/kubernetes, so we can't use github.com/openshift/kubernetes
+# directly. Instead, we'll construct the pseudo-version from git information.
+export GOPROXY="https://proxy.golang.org,direct"
+
+# The script uses GOPRIVATE and GONOSUMDB internally during version resolution, but the resulting go.mod and go.sum 
+# files work without those environment variables, which is required for the downstreaming process with 
+# operator-framework-tooling.
+export GOPRIVATE="github.com/openshift/*"
+export GONOSUMDB="github.com/openshift/*"
+
+echo "Resolving pseudo-version for k8s.io/kubernetes@${OCP_COMMIT}…"
+
+# Clone the repo temporarily to get commit timestamp
+TMP_DIR=$(mktemp -d)
+trap "rm -rf ${TMP_DIR}" EXIT
+
+git clone --depth=1 "${OCP_REMOTE}" "${TMP_DIR}" >/dev/null 2>&1
+cd "${TMP_DIR}"
+git checkout "${OCP_COMMIT}" >/dev/null 2>&1 || {
+    cd - >/dev/null
+    die "could not checkout commit ${OCP_COMMIT}"
+}
+
+# Get commit timestamp in the format YYYYMMDDHHMMSS
+COMMIT_TIME=$(git log -1 --format=%ct "${OCP_COMMIT}")
+COMMIT_DATE=$(date -u -r "${COMMIT_TIME}" +%Y%m%d%H%M%S 2>/dev/null || date -u -d "@${COMMIT_TIME}" +%Y%m%d%H%M%S 2>/dev/null || echo "")
+SHORT_SHA="${OCP_COMMIT:0:12}"
+
+cd - >/dev/null
+rm -rf "${TMP_DIR}"
+trap - EXIT
+
+if [[ -z "$COMMIT_DATE" ]]; then
+    die "could not get commit timestamp for ${OCP_COMMIT}"
+fi
+
+# Construct pseudo-version: v0.0.0-YYYYMMDDHHMMSS-<short-sha>
+OCP_VERSION="v0.0.0-${COMMIT_DATE}-${SHORT_SHA}"
+echo "Resolved OCP version: ${OCP_VERSION}"
+
+echo "Updating go.mod replaces…"
+
+# Clean up any existing replace directives for k8s.io modules first
+# This ensures we start with a clean slate
+for m in k8s.io/kubernetes "${STAGING_MODULES[@]}"; do
+    go mod edit -dropreplace "${m}" 2>/dev/null || true
+done
+go mod edit -dropreplace "github.com/onsi/ginkgo/v2" 2>/dev/null || true
+
+# 1) OCP Ginkgo fork
+go mod edit -replace "github.com/onsi/ginkgo/v2=${GINKGO_FORK}@${GINKGO_VERSION}"
+
+# 2) Root k8s.io/kubernetes → OCP fork
+go mod edit -replace "k8s.io/kubernetes=${OCP_REPO}@${OCP_VERSION}"
+
+# 3) All staging modules → staging path in the OCP fork at the same version
+for m in "${STAGING_MODULES[@]}"; do
+  go mod edit -replace "${m}=${OCP_REPO}/staging/src/${m}@${OCP_VERSION}"
+done
+
+# 4) Tidy up
+go mod tidy
+go mod vendor
+
+echo
+echo "Done."
+echo "  OCP commit:  ${OCP_COMMIT}"
+echo "  OCP version: ${OCP_VERSION}"
+echo "go.mod and go.sum vendor/ updated."

--- a/openshift/tests-extension/vendor/modules.txt
+++ b/openshift/tests-extension/vendor/modules.txt
@@ -1139,7 +1139,7 @@ k8s.io/kubectl/pkg/util/podutils
 ## explicit; go 1.24.0
 k8s.io/kubelet/pkg/apis
 k8s.io/kubelet/pkg/apis/stats/v1alpha1
-# k8s.io/kubernetes v1.34.1 => github.com/openshift/kubernetes v1.30.1-0.20251108023427-891f5bb03061
+# k8s.io/kubernetes v1.34.1 => github.com/openshift/kubernetes v0.0.0-20251108023427-891f5bb03061
 ## explicit; go 1.24.0
 k8s.io/kubernetes/pkg/api/legacyscheme
 k8s.io/kubernetes/pkg/api/service
@@ -1233,7 +1233,7 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20250416174521-4eb003743b54
-# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
+# k8s.io/kubernetes => github.com/openshift/kubernetes v0.0.0-20251108023427-891f5bb03061
 # k8s.io/api => github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20251108023427-891f5bb03061
 # k8s.io/apiextensions-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20251108023427-891f5bb03061
 # k8s.io/apimachinery => github.com/openshift/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20251108023427-891f5bb03061
@@ -1258,7 +1258,6 @@ sigs.k8s.io/yaml
 # k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20251108023427-891f5bb03061
 # k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20251108023427-891f5bb03061
 # k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20251108023427-891f5bb03061
-# k8s.io/kubernetes => github.com/openshift/kubernetes v1.30.1-0.20251108023427-891f5bb03061
 # k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20251108023427-891f5bb03061
 # k8s.io/mount-utils => github.com/openshift/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20251108023427-891f5bb03061
 # k8s.io/pod-security-admission => github.com/openshift/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20251108023427-891f5bb03061


### PR DESCRIPTION
## Problem

After merging #544, the [operator-framework-tooling](https://github.com/openshift/operator-framework-tooling) bumper started failing when attempting to verify the synthetic versions of `github.com/openshift/kubernetes` modules. The bumper encounters the following errors:

1. **404 Not Found**: The synthetic version `github.com/openshift/kubernetes@v1.30.1-0.20251108023427-891f5bb03061` does not exist in the Go module proxy
2. **500 Internal Server Error**: When attempting to verify checksums via `sum.golang.org`, the service returns a 500 error

These errors occur because:
- The OpenShift Kubernetes fork uses pseudo-versions that aren't published to the public Go module proxy
- The Go checksum database (`sum.golang.org`) cannot verify these private fork modules
- The bumper tool runs `go mod tidy` and `go mod vendor` without special environment variables (`GOPRIVATE`/`GONOSUMDB`), causing verification failures

## Solution

Fix the version format issue and add a helper script to properly manage OpenShift Kubernetes fork replaces. The key changes:

1. **Fixed version format**: Changed `k8s.io/kubernetes` replace from `v1.30.1-0.20251108023427-891f5bb03061` to `v0.0.0-20251108023427-891f5bb03061` to use the correct pseudo-version format that works with the Go module system
2. **Added helper script**: Created `hack/ocp-replace.sh` to properly construct and update OpenShift Kubernetes fork replaces, handling the module path mismatch between `k8s.io/kubernetes` and `github.com/openshift/kubernetes`
3. **Compatible with bumper tooling**: The script uses `GOPRIVATE` and `GONOSUMDB` internally during version resolution, but produces `go.mod`/`go.sum` files that work without those environment variables, making it compatible with the downstreaming process
4. **Review the replaces**: Remove `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` replace directive (no longer needed)

## Tests

```
$ make build
GO_COMPLIANCE_POLICY="exempt_all" go build -ldflags "-X 'github.com/openshift-eng/openshift-tests-extension/pkg/version.CommitFromGit=ec0a4ae45' -X 'github.com/openshift-eng/openshift-tests-extension/pkg/version.BuildDate=2025-11-10T18:37:15Z' -X 'github.com/openshift-eng/openshift-tests-extension/pkg/version.GitTreeState=clean'" -mod=vendor -o /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/bin/olmv1-tests-ext ./cmd/...
```

```
$ ./bin/olmv1-tests-ext run-suite olmv1/all
  [INFO] [env] Using kubeconfig: /Users/camilam/.kube/cluster-bot.kubeconfig
  [INFO] [env] Cluster environment initialized (OpenShift: true)
[
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog should serve FBC via the /v1/api/metas endpoint",
    "lifecycle": "blocking",
    "duration": 670,
    "startTime": "2025-11-10 18:47:38.382224 UTC",
    "endTime": "2025-11-10 18:47:39.052548 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-community-operators\" @ 11/10/25 18:47:38.508\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-community-operators/api/v1/metas?schema=olm.package @ 11/10/25 18:47:38.633\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.769\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-marketplace Catalog should serve FBC via the /v1/api/all endpoint",
    "lifecycle": "blocking",
    "duration": 669,
    "startTime": "2025-11-10 18:47:38.398869 UTC",
    "endTime": "2025-11-10 18:47:39.068291 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-redhat-marketplace\" @ 11/10/25 18:47:38.523\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-redhat-marketplace/api/v1/all @ 11/10/25 18:47:38.65\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.78\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog should serve FBC via the /v1/api/metas endpoint",
    "lifecycle": "blocking",
    "duration": 681,
    "startTime": "2025-11-10 18:47:38.397567 UTC",
    "endTime": "2025-11-10 18:47:39.079192 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-certified-operators\" @ 11/10/25 18:47:38.525\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-certified-operators/api/v1/metas?schema=olm.package @ 11/10/25 18:47:38.649\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.786\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/metas endpoint",
    "lifecycle": "blocking",
    "duration": 678,
    "startTime": "2025-11-10 18:47:38.403900 UTC",
    "endTime": "2025-11-10 18:47:39.082229 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-redhat-operators\" @ 11/10/25 18:47:38.53\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-redhat-operators/api/v1/metas?schema=olm.package @ 11/10/25 18:47:38.652\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.786\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog should serve FBC via the /v1/api/all endpoint",
    "lifecycle": "blocking",
    "duration": 684,
    "startTime": "2025-11-10 18:47:38.409641 UTC",
    "endTime": "2025-11-10 18:47:39.094402 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-community-operators\" @ 11/10/25 18:47:38.545\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-community-operators/api/v1/all @ 11/10/25 18:47:38.672\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.803\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-marketplace Catalog should serve FBC via the /v1/api/metas endpoint",
    "lifecycle": "blocking",
    "duration": 733,
    "startTime": "2025-11-10 18:47:38.432129 UTC",
    "endTime": "2025-11-10 18:47:39.166092 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-redhat-marketplace\" @ 11/10/25 18:47:38.562\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-redhat-marketplace/api/v1/metas?schema=olm.package @ 11/10/25 18:47:38.696\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.864\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog should serve FBC via the /v1/api/all endpoint",
    "lifecycle": "blocking",
    "duration": 746,
    "startTime": "2025-11-10 18:47:38.432157 UTC",
    "endTime": "2025-11-10 18:47:39.178703 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-certified-operators\" @ 11/10/25 18:47:38.571\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-certified-operators/api/v1/all @ 11/10/25 18:47:38.701\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.843\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs should be installed",
    "lifecycle": "blocking",
    "duration": 653,
    "startTime": "2025-11-10 18:47:38.531794 UTC",
    "endTime": "2025-11-10 18:47:39.185741 UTC",
    "result": "passed",
    "output": "  STEP: checking that \"openshift-certified-operators\" exists @ 11/10/25 18:47:38.661\n  STEP: checking that \"openshift-certified-operators\" is serving @ 11/10/25 18:47:38.793\n  STEP: checking that \"openshift-community-operators\" exists @ 11/10/25 18:47:38.793\n  STEP: checking that \"openshift-community-operators\" is serving @ 11/10/25 18:47:38.93\n  STEP: checking that \"openshift-redhat-marketplace\" exists @ 11/10/25 18:47:38.93\n  STEP: checking that \"openshift-redhat-marketplace\" is serving @ 11/10/25 18:47:39.058\n  STEP: checking that \"openshift-redhat-operators\" exists @ 11/10/25 18:47:39.058\n  STEP: checking that \"openshift-redhat-operators\" is serving @ 11/10/25 18:47:39.185\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/all endpoint",
    "lifecycle": "blocking",
    "duration": 660,
    "startTime": "2025-11-10 18:47:38.546397 UTC",
    "endTime": "2025-11-10 18:47:39.206927 UTC",
    "result": "passed",
    "output": "  STEP: Retrieving base URL from ClusterCatalog \"openshift-redhat-operators\" @ 11/10/25 18:47:38.674\n  STEP: Creating curl Job to hit: https://catalogd-service.openshift-catalogd.svc/catalogs/openshift-redhat-operators/api/v1/all @ 11/10/25 18:47:38.809\n  STEP: Waiting for Job to succeed @ 11/10/25 18:47:38.942\n"
  },
  {
    "name": "[sig-olmv1][Jira:OLM] clusterextension PolarionID:83069-[OTP]olmv1 static networkpolicy.",
    "lifecycle": "blocking",
    "duration": 8694,
    "startTime": "2025-11-10 18:47:38.477922 UTC",
    "endTime": "2025-11-10 18:47:47.172305 UTC",
    "result": "passed",
    "output": "  STEP: Creating a kubernetes client @ 11/10/25 18:47:38.478\nI1110 18:47:43.482960 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig explain template.apiVersion'\n  STEP: Checking NP catalogd-controller-manager in openshift-catalogd @ 11/10/25 18:47:44.149\nI1110 18:47:44.149785 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy catalogd-controller-manager -n openshift-catalogd -o=jsonpath={.spec}'\nI1110 18:47:44.549191 41452 olmv1_ce.go:152] specs: {\"egress\":[{}],\"ingress\":[{\"ports\":[{\"port\":7443,\"protocol\":\"TCP\"},{\"port\":8443,\"protocol\":\"TCP\"},{\"port\":9443,\"protocol\":\"TCP\"}]}],\"podSelector\":{\"matchLabels\":{\"control-plane\":\"catalogd-controller-manager\"}},\"policyTypes\":[\"Ingress\",\"Egress\"]}\n  STEP: Checking NP catalogd-default-deny-all-traffic in openshift-catalogd @ 11/10/25 18:47:44.549\nI1110 18:47:44.549605 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy catalogd-default-deny-all-traffic -n openshift-catalogd -o=jsonpath={.spec}'\nI1110 18:47:44.900748 41452 olmv1_ce.go:152] specs: {\"podSelector\":{},\"policyTypes\":[\"Ingress\",\"Egress\"]}\n  STEP: Checking NP allow-egress-to-api-server in openshift-cluster-olm-operator @ 11/10/25 18:47:44.9\nI1110 18:47:44.901030 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy allow-egress-to-api-server -n openshift-cluster-olm-operator -o=jsonpath={.spec}'\nI1110 18:47:45.286447 41452 olmv1_ce.go:152] specs: {\"egress\":[{\"ports\":[{\"port\":6443,\"protocol\":\"TCP\"}]}],\"podSelector\":{\"matchLabels\":{\"name\":\"cluster-olm-operator\"}},\"policyTypes\":[\"Egress\"]}\n  STEP: Checking NP allow-egress-to-openshift-dns in openshift-cluster-olm-operator @ 11/10/25 18:47:45.286\nI1110 18:47:45.286786 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy allow-egress-to-openshift-dns -n openshift-cluster-olm-operator -o=jsonpath={.spec}'\nI1110 18:47:45.667047 41452 olmv1_ce.go:152] specs: {\"egress\":[{\"ports\":[{\"port\":\"dns-tcp\",\"protocol\":\"TCP\"},{\"port\":\"dns\",\"protocol\":\"UDP\"}],\"to\":[{\"namespaceSelector\":{\"matchLabels\":{\"kubernetes.io/metadata.name\":\"openshift-dns\"}}}]}],\"podSelector\":{\"matchLabels\":{\"name\":\"cluster-olm-operator\"}},\"policyTypes\":[\"Egress\"]}\n  STEP: Checking NP allow-metrics-traffic in openshift-cluster-olm-operator @ 11/10/25 18:47:45.667\nI1110 18:47:45.667364 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy allow-metrics-traffic -n openshift-cluster-olm-operator -o=jsonpath={.spec}'\nI1110 18:47:46.026801 41452 olmv1_ce.go:152] specs: {\"ingress\":[{\"from\":[{\"namespaceSelector\":{\"matchLabels\":{\"name\":\"openshift-monitoring\"}}}],\"ports\":[{\"port\":8443,\"protocol\":\"TCP\"}]}],\"podSelector\":{\"matchLabels\":{\"name\":\"cluster-olm-operator\"}},\"policyTypes\":[\"Ingress\"]}\n  STEP: Checking NP default-deny-all in openshift-cluster-olm-operator @ 11/10/25 18:47:46.026\nI1110 18:47:46.027161 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy default-deny-all -n openshift-cluster-olm-operator -o=jsonpath={.spec}'\nI1110 18:47:46.419510 41452 olmv1_ce.go:152] specs: {\"podSelector\":{},\"policyTypes\":[\"Ingress\",\"Egress\"]}\n  STEP: Checking NP operator-controller-controller-manager in openshift-operator-controller @ 11/10/25 18:47:46.419\nI1110 18:47:46.419646 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy operator-controller-controller-manager -n openshift-operator-controller -o=jsonpath={.spec}'\nI1110 18:47:46.788264 41452 olmv1_ce.go:152] specs: {\"egress\":[{}],\"ingress\":[{\"ports\":[{\"port\":8443,\"protocol\":\"TCP\"}]}],\"podSelector\":{\"matchLabels\":{\"control-plane\":\"operator-controller-controller-manager\"}},\"policyTypes\":[\"Ingress\",\"Egress\"]}\n  STEP: Checking NP operator-controller-default-deny-all-traffic in openshift-operator-controller @ 11/10/25 18:47:46.788\nI1110 18:47:46.788532 41452 client.go:729] Running 'oc --kubeconfig=/Users/camilam/.kube/cluster-bot.kubeconfig get networkpolicy operator-controller-default-deny-all-traffic -n openshift-operator-controller -o=jsonpath={.spec}'\nI1110 18:47:47.170869 41452 olmv1_ce.go:152] specs: {\"podSelector\":{},\"policyTypes\":[\"Ingress\",\"Egress\"]}\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New Catalog Install should fail to install if it has an invalid reference",
    "lifecycle": "blocking",
    "duration": 75970,
    "startTime": "2025-11-10 18:47:40.001316 UTC",
    "endTime": "2025-11-10 18:48:55.972185 UTC",
    "result": "passed",
    "output": "  STEP: creating the malformed catalog with an invalid image ref @ 11/10/25 18:47:40.134\n  STEP: waiting for the catalog to report failure via Progressing=True and reason=Retrying @ 11/10/25 18:47:40.269\n  STEP: deleting lingering ClusterCatalog \"bad-catalog-ktrj\" @ 11/10/25 18:47:43.823\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 operator installation support for singleNamespace watch mode with operator should install a cluster extension successfully",
    "lifecycle": "blocking",
    "duration": 81703,
    "startTime": "2025-11-10 18:47:40.140499 UTC",
    "endTime": "2025-11-10 18:49:01.844371 UTC",
    "result": "passed",
    "output": "  STEP: checking if OpenShift is available for tests @ 11/10/25 18:47:40.14\n[INFO] Image-registry is available with 2 pod(s) running  STEP: using singleown operator image: quay.io/olmtest/webhook-operator:v0.0.5, CRD suffix: h9wc, package: singleown-operator-single-h9wc @ 11/10/25 18:47:40.402\n  STEP: setting a unique value: \"6m29q8kk\" @ 11/10/25 18:47:40.825\n  STEP: creating a new Namespace @ 11/10/25 18:47:40.825\n  STEP: waiting for builder serviceaccount in install-test-ns-6m29q8kk @ 11/10/25 18:47:40.959\n  STEP: waiting for deployer serviceaccount in install-test-ns-6m29q8kk @ 11/10/25 18:47:41.107\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:47:41.23\n  STEP: creating the operator BuildConfig @ 11/10/25 18:47:41.375\n  STEP: creating the operator ImageStream @ 11/10/25 18:47:41.514\n  STEP: creating the operator tarball @ 11/10/25 18:47:41.637\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-893863849.tar\" @ 11/10/25 18:47:41.639\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:47:41.639\n  STEP: waiting for the build \"install-test-op-6m29q8kk-1\" to finish @ 11/10/25 18:47:46.402\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:48:02.144\n  STEP: creating the catalog ImageStream @ 11/10/25 18:48:02.286\n  STEP: creating the catalog tarball @ 11/10/25 18:48:02.412\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3144487803.tar\" @ 11/10/25 18:48:02.413\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:48:02.413\n  STEP: waiting for the build \"install-test-cc-6m29q8kk-1\" to finish @ 11/10/25 18:48:05.634\n  STEP: creating the ClusterCatalog @ 11/10/25 18:48:18.254\n  STEP: singleown bundle \"install-test-op-6m29q8kk\" and catalog \"install-test-cc-6m29q8kk\" built successfully in namespace \"install-test-ns-6m29q8kk\" @ 11/10/25 18:48:55.992\n  STEP: creating namespace olmv1-singlens-ns-h9wc for single-namespace tests @ 11/10/25 18:48:55.992\n  STEP: creating ServiceAccount @ 11/10/25 18:48:56.128\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:48:56.265\n  STEP: registering cleanup for ServiceAccount @ 11/10/25 18:48:56.383\n  STEP: creating ClusterRoleBinding @ 11/10/25 18:48:56.383\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:48:56.513\n  STEP: registering cleanup for ClusterRoleBinding @ 11/10/25 18:48:56.635\n  STEP: creating ClusterExtension with the watch-namespace configured @ 11/10/25 18:48:56.635\n  STEP: registering cleanup for ClusterExtension @ 11/10/25 18:48:56.765\n  STEP: waiting for the ClusterExtension to be installed @ 11/10/25 18:48:56.765\n  STEP: cleanup: deleting ClusterExtension install-singlens-ce-h9wc @ 11/10/25 18:49:00.013\n  STEP: ensuring ClusterExtension is deleted @ 11/10/25 18:49:00.15\n  STEP: cleanup: deleting ClusterRoleBinding install-singlens-crb-h9wc @ 11/10/25 18:49:00.465\n  STEP: cleanup: deleting ServiceAccount install-singlens-sa-h9wc in namespace olmv1-singlens-ns-h9wc @ 11/10/25 18:49:00.605\n  STEP: cleaning up namespace olmv1-singlens-ns-h9wc @ 11/10/25 18:49:00.75\n  STEP: deleting ClusterCatalog \"install-test-cc-6m29q8kk\" @ 11/10/25 18:49:00.897\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3144487803.tar\" @ 11/10/25 18:49:01.042\n  STEP: deleting ImageStream \"install-test-cc-6m29q8kk\" @ 11/10/25 18:49:01.043\n  STEP: deleting BuildConfig \"install-test-cc-6m29q8kk\" @ 11/10/25 18:49:01.179\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-893863849.tar\" @ 11/10/25 18:49:01.313\n  STEP: deleting ImageStream \"install-test-op-6m29q8kk\" @ 11/10/25 18:49:01.314\n  STEP: deleting BuildConfig \"install-test-op-6m29q8kk\" @ 11/10/25 18:49:01.447\n  STEP: deleting image-puller RoleBinding \"install-test-rb-6m29q8kk\" @ 11/10/25 18:49:01.582\n  STEP: deleting Namespace \"install-test-ns-6m29q8kk\" @ 11/10/25 18:49:01.715\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {ClusterRoleBindings} are not specified",
    "lifecycle": "blocking",
    "duration": 82888,
    "startTime": "2025-11-10 18:47:40.037676 UTC",
    "endTime": "2025-11-10 18:49:02.926050 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace preflight-test-ns-4glb @ 11/10/25 18:47:40.165\n  STEP: waiting for ClusterExtension to report preflight failure @ 11/10/25 18:47:40.851\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {create} verb is not specified",
    "lifecycle": "blocking",
    "duration": 82992,
    "startTime": "2025-11-10 18:47:40.052584 UTC",
    "endTime": "2025-11-10 18:49:03.044791 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace preflight-test-ns-7pkn @ 11/10/25 18:47:40.189\n  STEP: waiting for ClusterExtension to report preflight failure @ 11/10/25 18:47:40.913\n"
  },
  {
    "name": "[sig-olmv1] OLMv1 should pass a trivial sanity check",
    "lifecycle": "blocking",
    "duration": 940,
    "startTime": "2025-11-10 18:49:03.982420 UTC",
    "endTime": "2025-11-10 18:49:03.983141 UTC",
    "result": "passed",
    "output": ""
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed",
    "lifecycle": "blocking",
    "duration": 388,
    "startTime": "2025-11-10 18:49:04.947797 UTC",
    "endTime": "2025-11-10 18:49:05.336187 UTC",
    "result": "passed",
    "output": "  STEP: verifying CRD clusterextensions.olm.operatorframework.io @ 11/10/25 18:49:05.076\n  STEP: verifying CRD clustercatalogs.olm.operatorframework.io @ 11/10/25 18:49:05.209\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {clusterextension/finalizer} is not specified",
    "lifecycle": "blocking",
    "duration": 86068,
    "startTime": "2025-11-10 18:47:40.152889 UTC",
    "endTime": "2025-11-10 18:49:06.220901 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace preflight-test-ns-bcbq @ 11/10/25 18:47:40.284\n  STEP: waiting for ClusterExtension to report preflight failure @ 11/10/25 18:47:40.987\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {escalate, bind} is not specified",
    "lifecycle": "blocking",
    "duration": 86126,
    "startTime": "2025-11-10 18:47:40.156462 UTC",
    "endTime": "2025-11-10 18:49:06.282744 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace preflight-test-ns-6slx @ 11/10/25 18:47:40.289\n  STEP: waiting for ClusterExtension to report preflight failure @ 11/10/25 18:47:41.023\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {services} are not specified",
    "lifecycle": "blocking",
    "duration": 86137,
    "startTime": "2025-11-10 18:47:40.166514 UTC",
    "endTime": "2025-11-10 18:49:06.303713 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace preflight-test-ns-f4nc @ 11/10/25 18:47:40.297\n  STEP: waiting for ClusterExtension to report preflight failure @ 11/10/25 18:47:41.012\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {ConfigMap:resourceNames} are not all specified",
    "lifecycle": "blocking",
    "duration": 89298,
    "startTime": "2025-11-10 18:47:40.260857 UTC",
    "endTime": "2025-11-10 18:49:09.558928 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace preflight-test-ns-n4j5 @ 11/10/25 18:47:40.438\n  STEP: waiting for ClusterExtension to report preflight failure @ 11/10/25 18:47:41.157\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed",
    "lifecycle": "blocking",
    "duration": 91157,
    "startTime": "2025-11-10 18:47:40.016928 UTC",
    "endTime": "2025-11-10 18:49:11.174694 UTC",
    "result": "passed",
    "output": "  STEP: setting a unique value: \"nhbw7k8m\" @ 11/10/25 18:47:40.148\n  STEP: creating a new Namespace @ 11/10/25 18:47:40.149\n  STEP: waiting for builder serviceaccount in install-test-ns-nhbw7k8m @ 11/10/25 18:47:40.285\n  STEP: waiting for deployer serviceaccount in install-test-ns-nhbw7k8m @ 11/10/25 18:47:40.438\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:47:40.594\n  STEP: creating the operator BuildConfig @ 11/10/25 18:47:40.845\n  STEP: creating the operator ImageStream @ 11/10/25 18:47:40.997\n  STEP: creating the operator tarball @ 11/10/25 18:47:41.139\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1716718877.tar\" @ 11/10/25 18:47:41.141\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:47:41.141\n  STEP: waiting for the build \"install-test-op-nhbw7k8m-1\" to finish @ 11/10/25 18:47:46.432\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:48:02.199\n  STEP: creating the catalog ImageStream @ 11/10/25 18:48:02.332\n  STEP: creating the catalog tarball @ 11/10/25 18:48:02.464\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1842481463.tar\" @ 11/10/25 18:48:02.465\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:48:02.465\n  STEP: waiting for the build \"install-test-cc-nhbw7k8m-1\" to finish @ 11/10/25 18:48:05.674\n  STEP: creating the ClusterCatalog @ 11/10/25 18:48:18.305\n  STEP: waiting for InstalledOLMOperatorUpgradable to be true @ 11/10/25 18:48:59.196\n  STEP: creating the ClusterExtension @ 11/10/25 18:48:59.328\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:48:59.449\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:48:59.7\n  STEP: waiting for InstalledOLMOperatorUpgradable to be false @ 11/10/25 18:49:09.441\n  STEP: waiting for ClusterOperator Upgradeable to be false @ 11/10/25 18:49:09.568\n  STEP: deleting CluserExtension, ClusterRoleBinding and ServiceAccount @ 11/10/25 18:49:09.693\n  STEP: deleting ClusterCatalog \"install-test-cc-nhbw7k8m\" @ 11/10/25 18:49:10.085\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1842481463.tar\" @ 11/10/25 18:49:10.271\n  STEP: deleting ImageStream \"install-test-cc-nhbw7k8m\" @ 11/10/25 18:49:10.272\n  STEP: deleting BuildConfig \"install-test-cc-nhbw7k8m\" @ 11/10/25 18:49:10.412\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1716718877.tar\" @ 11/10/25 18:49:10.556\n  STEP: deleting ImageStream \"install-test-op-nhbw7k8m\" @ 11/10/25 18:49:10.557\n  STEP: deleting BuildConfig \"install-test-op-nhbw7k8m\" @ 11/10/25 18:49:10.739\n  STEP: deleting image-puller RoleBinding \"install-test-rb-nhbw7k8m\" @ 11/10/25 18:49:10.907\n  STEP: deleting Namespace \"install-test-ns-nhbw7k8m\" @ 11/10/25 18:49:11.041\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 operator installation support for ownNamespace watch mode with operator should install a cluster extension successfully",
    "lifecycle": "blocking",
    "duration": 86513,
    "startTime": "2025-11-10 18:47:48.140936 UTC",
    "endTime": "2025-11-10 18:49:14.654831 UTC",
    "result": "passed",
    "output": "  STEP: checking if OpenShift is available for tests @ 11/10/25 18:47:48.141\n[INFO] Image-registry is available with 2 pod(s) running  STEP: using singleown operator image: quay.io/olmtest/webhook-operator:v0.0.5, CRD suffix: nv5k, package: singleown-operator-own-nv5k @ 11/10/25 18:47:48.397\n  STEP: setting a unique value: \"lm7ccljm\" @ 11/10/25 18:47:48.775\n  STEP: creating a new Namespace @ 11/10/25 18:47:48.775\n  STEP: waiting for builder serviceaccount in install-test-ns-lm7ccljm @ 11/10/25 18:47:48.902\n  STEP: waiting for deployer serviceaccount in install-test-ns-lm7ccljm @ 11/10/25 18:47:49.033\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:47:49.158\n  STEP: creating the operator BuildConfig @ 11/10/25 18:47:49.301\n  STEP: creating the operator ImageStream @ 11/10/25 18:47:49.435\n  STEP: creating the operator tarball @ 11/10/25 18:47:49.565\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-985269616.tar\" @ 11/10/25 18:47:49.567\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:47:49.567\n  STEP: waiting for the build \"install-test-op-lm7ccljm-1\" to finish @ 11/10/25 18:47:53.128\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:48:08.894\n  STEP: creating the catalog ImageStream @ 11/10/25 18:48:09.027\n  STEP: creating the catalog tarball @ 11/10/25 18:48:09.157\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1353143076.tar\" @ 11/10/25 18:48:09.161\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:48:09.161\n  STEP: waiting for the build \"install-test-cc-lm7ccljm-1\" to finish @ 11/10/25 18:48:12.257\n  STEP: creating the ClusterCatalog @ 11/10/25 18:48:24.897\n  STEP: singleown bundle \"install-test-op-lm7ccljm\" and catalog \"install-test-cc-lm7ccljm\" built successfully in namespace \"install-test-ns-lm7ccljm\" @ 11/10/25 18:48:59.5\n  STEP: creating namespace olmv1-ownns-ns-nv5k for own-namespace tests @ 11/10/25 18:48:59.501\n  STEP: creating ServiceAccount @ 11/10/25 18:48:59.628\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:48:59.752\n  STEP: registering cleanup for ServiceAccount @ 11/10/25 18:48:59.874\n  STEP: creating ClusterRoleBinding @ 11/10/25 18:48:59.874\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:48:59.999\n  STEP: registering cleanup for ClusterRoleBinding @ 11/10/25 18:49:00.122\n  STEP: creating ClusterExtension with the watch-namespace configured @ 11/10/25 18:49:00.122\n  STEP: registering cleanup for ClusterExtension @ 11/10/25 18:49:00.259\n  STEP: waiting for the ClusterExtension to be installed @ 11/10/25 18:49:00.259\n  STEP: cleanup: deleting ClusterExtension install-ownns-ce-nv5k @ 11/10/25 18:49:12.877\n  STEP: ensuring ClusterExtension is deleted @ 11/10/25 18:49:13.023\n  STEP: cleanup: deleting ClusterRoleBinding install-ownns-crb-nv5k @ 11/10/25 18:49:13.3\n  STEP: cleanup: deleting ServiceAccount install-ownns-sa-nv5k in namespace olmv1-ownns-ns-nv5k @ 11/10/25 18:49:13.439\n  STEP: cleaning up namespace olmv1-ownns-ns-nv5k @ 11/10/25 18:49:13.579\n  STEP: deleting ClusterCatalog \"install-test-cc-lm7ccljm\" @ 11/10/25 18:49:13.709\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1353143076.tar\" @ 11/10/25 18:49:13.837\n  STEP: deleting ImageStream \"install-test-cc-lm7ccljm\" @ 11/10/25 18:49:13.838\n  STEP: deleting BuildConfig \"install-test-cc-lm7ccljm\" @ 11/10/25 18:49:13.974\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-985269616.tar\" @ 11/10/25 18:49:14.104\n  STEP: deleting ImageStream \"install-test-op-lm7ccljm\" @ 11/10/25 18:49:14.104\n  STEP: deleting BuildConfig \"install-test-op-lm7ccljm\" @ 11/10/25 18:49:14.24\n  STEP: deleting image-puller RoleBinding \"install-test-rb-lm7ccljm\" @ 11/10/25 18:49:14.392\n  STEP: deleting Namespace \"install-test-ns-lm7ccljm\" @ 11/10/25 18:49:14.527\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should install an openshift catalog cluster extension",
    "lifecycle": "blocking",
    "duration": 11342,
    "startTime": "2025-11-10 18:49:06.272772 UTC",
    "endTime": "2025-11-10 18:49:17.615627 UTC",
    "result": "passed",
    "output": "  STEP: creating namespace install-test-ns-gszg @ 11/10/25 18:49:06.392\n  STEP: ensuring no ClusterExtension and CRD for quay-operator @ 11/10/25 18:49:06.535\n  STEP: applying the ClusterExtension resource @ 11/10/25 18:49:06.791\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:49:06.917\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:49:07.176\n  STEP: waiting for the quay-operator ClusterExtension to be installed @ 11/10/25 18:49:07.429\n  STEP: deleting CluserExtension, ClusterRoleBinding and ServiceAccount @ 11/10/25 18:49:17.019\n  STEP: deleting namespace install-test-ns-gszg @ 11/10/25 18:49:17.472\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace][Serial] OLMv1 operator installation support for ownNamespace watch mode with an operator that does not support ownNamespace installation mode should fail to install a cluster extension successfully",
    "lifecycle": "blocking",
    "duration": 46182,
    "startTime": "2025-11-10 18:49:02.821520 UTC",
    "endTime": "2025-11-10 18:49:49.004336 UTC",
    "result": "passed",
    "output": "  STEP: checking if OpenShift is available for tests @ 11/10/25 18:49:02.821\n[INFO] Image-registry is available with 2 pod(s) running  STEP: using webhook operator image: quay.io/olmtest/webhook-operator:v0.0.5, CRD suffix:  @ 11/10/25 18:49:03.082\n  STEP: setting a unique value: \"l96zzg4j\" @ 11/10/25 18:49:03.211\n  STEP: creating a new Namespace @ 11/10/25 18:49:03.211\n  STEP: waiting for builder serviceaccount in install-test-ns-l96zzg4j @ 11/10/25 18:49:03.344\n  STEP: waiting for deployer serviceaccount in install-test-ns-l96zzg4j @ 11/10/25 18:49:03.47\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:03.599\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:03.734\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:03.872\n  STEP: creating the operator tarball @ 11/10/25 18:49:04.003\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3184802864.tar\" @ 11/10/25 18:49:04.005\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:04.005\n  STEP: waiting for the build \"install-test-op-l96zzg4j-1\" to finish @ 11/10/25 18:49:07.244\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:23.014\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:23.158\n  STEP: creating the catalog tarball @ 11/10/25 18:49:23.342\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-132561664.tar\" @ 11/10/25 18:49:23.344\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:23.344\n  STEP: waiting for the build \"install-test-cc-l96zzg4j-1\" to finish @ 11/10/25 18:49:26.841\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:39.48\n  STEP: webhook bundle \"install-test-op-l96zzg4j\" and catalog \"install-test-cc-l96zzg4j\" built successfully in namespace \"install-test-ns-l96zzg4j\" @ 11/10/25 18:49:42.863\n  STEP: ensuring no ClusterExtension for webhook-operator @ 11/10/25 18:49:42.863\n  STEP: creating namespace olmv1-pipelines-ns-4nb7 for failing tests @ 11/10/25 18:49:43.119\n  STEP: creating ServiceAccount @ 11/10/25 18:49:43.249\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:49:43.402\n  STEP: registering cleanup for ServiceAccount @ 11/10/25 18:49:43.533\n  STEP: creating ClusterRoleBinding @ 11/10/25 18:49:43.533\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:49:43.66\n  STEP: registering cleanup for ClusterRoleBinding @ 11/10/25 18:49:43.783\n  STEP: creating ClusterExtension with the watch-namespace configured using webhook operator that only supports AllNamespaces mode @ 11/10/25 18:49:43.783\n  STEP: registering cleanup for ClusterExtension @ 11/10/25 18:49:43.913\n  STEP: waiting for the ClusterExtension to fail installation @ 11/10/25 18:49:43.913\n  STEP: cleanup: deleting ClusterExtension install-pipelines-ce-4nb7 @ 11/10/25 18:49:47.159\n  STEP: ensuring ClusterExtension is deleted @ 11/10/25 18:49:47.295\n  STEP: cleanup: deleting ClusterRoleBinding install-pipelines-crb-4nb7 @ 11/10/25 18:49:47.542\n  STEP: cleanup: deleting ServiceAccount install-pipelines-sa-4nb7 in namespace olmv1-pipelines-ns-4nb7 @ 11/10/25 18:49:47.675\n  STEP: cleaning up namespace olmv1-pipelines-ns-4nb7 @ 11/10/25 18:49:47.807\n  STEP: deleting ClusterCatalog \"install-test-cc-l96zzg4j\" @ 11/10/25 18:49:48.08\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-132561664.tar\" @ 11/10/25 18:49:48.209\n  STEP: deleting ImageStream \"install-test-cc-l96zzg4j\" @ 11/10/25 18:49:48.209\n  STEP: deleting BuildConfig \"install-test-cc-l96zzg4j\" @ 11/10/25 18:49:48.343\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3184802864.tar\" @ 11/10/25 18:49:48.478\n  STEP: deleting ImageStream \"install-test-op-l96zzg4j\" @ 11/10/25 18:49:48.479\n  STEP: deleting BuildConfig \"install-test-op-l96zzg4j\" @ 11/10/25 18:49:48.609\n  STEP: deleting image-puller RoleBinding \"install-test-rb-l96zzg4j\" @ 11/10/25 18:49:48.743\n  STEP: deleting Namespace \"install-test-ns-l96zzg4j\" @ 11/10/25 18:49:48.872\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 operator installation should reject invalid watch namespace configuration and update the status conditions accordingly should fail to install the ClusterExtension when watch namespace is invalid",
    "lifecycle": "blocking",
    "duration": 45988,
    "startTime": "2025-11-10 18:49:03.897077 UTC",
    "endTime": "2025-11-10 18:49:49.885537 UTC",
    "result": "passed",
    "output": "  STEP: checking if OpenShift is available for tests @ 11/10/25 18:49:03.897\n[INFO] Image-registry is available with 2 pod(s) running  STEP: using singleown operator image: quay.io/olmtest/webhook-operator:v0.0.5, CRD suffix: 9k46, package: singleown-operator-9k46 @ 11/10/25 18:49:04.153\n  STEP: setting a unique value: \"57pwxnmf\" @ 11/10/25 18:49:04.285\n  STEP: creating a new Namespace @ 11/10/25 18:49:04.285\n  STEP: waiting for builder serviceaccount in install-test-ns-57pwxnmf @ 11/10/25 18:49:04.412\n  STEP: waiting for deployer serviceaccount in install-test-ns-57pwxnmf @ 11/10/25 18:49:04.539\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:04.673\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:04.817\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:04.954\n  STEP: creating the operator tarball @ 11/10/25 18:49:05.08\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-351970887.tar\" @ 11/10/25 18:49:05.084\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:05.084\n  STEP: waiting for the build \"install-test-op-57pwxnmf-1\" to finish @ 11/10/25 18:49:08.575\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:24.362\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:24.495\n  STEP: creating the catalog tarball @ 11/10/25 18:49:24.624\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-424852099.tar\" @ 11/10/25 18:49:24.626\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:24.626\n  STEP: waiting for the build \"install-test-cc-57pwxnmf-1\" to finish @ 11/10/25 18:49:27.776\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:40.426\n  STEP: singleown bundle \"install-test-op-57pwxnmf\" and catalog \"install-test-cc-57pwxnmf\" built successfully in namespace \"install-test-ns-57pwxnmf\" @ 11/10/25 18:49:43.834\n  STEP: ensuring no lingering ClusterExtensions for singleown-operator-9k46 @ 11/10/25 18:49:43.834\n  STEP: creating namespace olmv1-invalidwatch-ns-9k46 for invalid watch namespace tests @ 11/10/25 18:49:44.089\n  STEP: creating ServiceAccount @ 11/10/25 18:49:44.221\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:49:44.354\n  STEP: creating ClusterRoleBinding @ 11/10/25 18:49:44.481\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:49:44.612\n  STEP: creating ClusterExtension with an invalid watch namespace configured @ 11/10/25 18:49:44.743\n  STEP: waiting for the ClusterExtension installation to fail due to invalid watch namespace @ 11/10/25 18:49:44.875\n  STEP: cleanup: deleting ClusterExtension install-invalidwatch-ce-9k46 @ 11/10/25 18:49:48.137\n  STEP: ensuring ClusterExtension is deleted @ 11/10/25 18:49:48.277\n  STEP: cleanup: deleting ClusterRoleBinding install-invalidwatch-crb-9k46 @ 11/10/25 18:49:48.542\n  STEP: cleanup: deleting ServiceAccount install-invalidwatch-sa-9k46 in namespace olmv1-invalidwatch-ns-9k46 @ 11/10/25 18:49:48.672\n  STEP: cleaning up namespace olmv1-invalidwatch-ns-9k46 @ 11/10/25 18:49:48.803\n  STEP: deleting ClusterCatalog \"install-test-cc-57pwxnmf\" @ 11/10/25 18:49:48.935\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-424852099.tar\" @ 11/10/25 18:49:49.069\n  STEP: deleting ImageStream \"install-test-cc-57pwxnmf\" @ 11/10/25 18:49:49.07\n  STEP: deleting BuildConfig \"install-test-cc-57pwxnmf\" @ 11/10/25 18:49:49.204\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-351970887.tar\" @ 11/10/25 18:49:49.346\n  STEP: deleting ImageStream \"install-test-op-57pwxnmf\" @ 11/10/25 18:49:49.347\n  STEP: deleting BuildConfig \"install-test-op-57pwxnmf\" @ 11/10/25 18:49:49.481\n  STEP: deleting image-puller RoleBinding \"install-test-rb-57pwxnmf\" @ 11/10/25 18:49:49.616\n  STEP: deleting Namespace \"install-test-ns-57pwxnmf\" @ 11/10/25 18:49:49.747\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation should install a cluster extension",
    "lifecycle": "blocking",
    "duration": 45060,
    "startTime": "2025-11-10 18:49:07.236412 UTC",
    "endTime": "2025-11-10 18:49:52.296656 UTC",
    "result": "passed",
    "output": "  STEP: setting a unique value: \"lvj2z7x7\" @ 11/10/25 18:49:07.366\n  STEP: creating a new Namespace @ 11/10/25 18:49:07.366\n  STEP: waiting for builder serviceaccount in install-test-ns-lvj2z7x7 @ 11/10/25 18:49:07.495\n  STEP: waiting for deployer serviceaccount in install-test-ns-lvj2z7x7 @ 11/10/25 18:49:07.615\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:07.758\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:07.904\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:08.042\n  STEP: creating the operator tarball @ 11/10/25 18:49:08.175\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2902129117.tar\" @ 11/10/25 18:49:08.177\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:08.177\n  STEP: waiting for the build \"install-test-op-lvj2z7x7-1\" to finish @ 11/10/25 18:49:11.542\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:27.342\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:27.477\n  STEP: creating the catalog tarball @ 11/10/25 18:49:27.609\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2552226230.tar\" @ 11/10/25 18:49:27.611\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:27.611\n  STEP: waiting for the build \"install-test-cc-lvj2z7x7-1\" to finish @ 11/10/25 18:49:30.834\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:43.496\n  STEP: ensuring no ClusterExtension and CRD for the operator @ 11/10/25 18:49:46.886\n  STEP: applying the ClusterExtension resource @ 11/10/25 18:49:47.014\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:49:47.147\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:49:47.392\n  STEP: waiting for the ClusterExtension to be installed @ 11/10/25 18:49:47.65\n  STEP: deleting CluserExtension, ClusterRoleBinding and ServiceAccount @ 11/10/25 18:49:50.899\n  STEP: deleting ClusterCatalog \"install-test-cc-lvj2z7x7\" @ 11/10/25 18:49:51.311\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2552226230.tar\" @ 11/10/25 18:49:51.448\n  STEP: deleting ImageStream \"install-test-cc-lvj2z7x7\" @ 11/10/25 18:49:51.448\n  STEP: deleting BuildConfig \"install-test-cc-lvj2z7x7\" @ 11/10/25 18:49:51.606\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2902129117.tar\" @ 11/10/25 18:49:51.744\n  STEP: deleting ImageStream \"install-test-op-lvj2z7x7\" @ 11/10/25 18:49:51.745\n  STEP: deleting BuildConfig \"install-test-op-lvj2z7x7\" @ 11/10/25 18:49:51.881\n  STEP: deleting image-puller RoleBinding \"install-test-rb-lvj2z7x7\" @ 11/10/25 18:49:52.017\n  STEP: deleting Namespace \"install-test-ns-lvj2z7x7\" @ 11/10/25 18:49:52.168\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation should fail to install a non-existing cluster extension",
    "lifecycle": "blocking",
    "duration": 45167,
    "startTime": "2025-11-10 18:49:07.382364 UTC",
    "endTime": "2025-11-10 18:49:52.549680 UTC",
    "result": "passed",
    "output": "  STEP: setting a unique value: \"8x6htbt5\" @ 11/10/25 18:49:07.515\n  STEP: creating a new Namespace @ 11/10/25 18:49:07.515\n  STEP: waiting for builder serviceaccount in install-test-ns-8x6htbt5 @ 11/10/25 18:49:07.644\n  STEP: waiting for deployer serviceaccount in install-test-ns-8x6htbt5 @ 11/10/25 18:49:07.77\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:08.031\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:08.182\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:08.328\n  STEP: creating the operator tarball @ 11/10/25 18:49:08.451\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3844286275.tar\" @ 11/10/25 18:49:08.451\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:08.451\n  STEP: waiting for the build \"install-test-op-8x6htbt5-1\" to finish @ 11/10/25 18:49:11.673\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:27.442\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:27.576\n  STEP: creating the catalog tarball @ 11/10/25 18:49:27.701\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2317472963.tar\" @ 11/10/25 18:49:27.702\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:27.702\n  STEP: waiting for the build \"install-test-cc-8x6htbt5-1\" to finish @ 11/10/25 18:49:30.864\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:43.499\n  STEP: ensuring no ClusterExtension and CRD for non-existing operator @ 11/10/25 18:49:46.878\n  STEP: applying the ClusterExtension resource @ 11/10/25 18:49:47.003\n  STEP: ensuring ServiceAccount is available before proceeding @ 11/10/25 18:49:47.134\n  STEP: ensuring ClusterRoleBinding is available before proceeding @ 11/10/25 18:49:47.392\n  STEP: waiting for the ClusterExtension to exist @ 11/10/25 18:49:47.65\n  STEP: waiting up to 2 minutes for ClusterExtension to report failure @ 11/10/25 18:49:47.768\n  STEP: deleting CluserExtension, ClusterRoleBinding and ServiceAccount @ 11/10/25 18:49:51.017\n  STEP: deleting ClusterCatalog \"install-test-cc-8x6htbt5\" @ 11/10/25 18:49:51.416\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2317472963.tar\" @ 11/10/25 18:49:51.606\n  STEP: deleting ImageStream \"install-test-cc-8x6htbt5\" @ 11/10/25 18:49:51.607\n  STEP: deleting BuildConfig \"install-test-cc-8x6htbt5\" @ 11/10/25 18:49:51.749\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3844286275.tar\" @ 11/10/25 18:49:51.88\n  STEP: deleting ImageStream \"install-test-op-8x6htbt5\" @ 11/10/25 18:49:51.881\n  STEP: deleting BuildConfig \"install-test-op-8x6htbt5\" @ 11/10/25 18:49:52.014\n  STEP: deleting image-puller RoleBinding \"install-test-rb-8x6htbt5\" @ 11/10/25 18:49:52.218\n  STEP: deleting Namespace \"install-test-ns-8x6htbt5\" @ 11/10/25 18:49:52.384\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should have a working validating webhook",
    "lifecycle": "blocking",
    "duration": 74846,
    "startTime": "2025-11-10 18:49:07.210264 UTC",
    "endTime": "2025-11-10 18:50:22.056401 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client @ 11/10/25 18:49:07.212\n  STEP: requiring OLMv1 capability on OpenShift @ 11/10/25 18:49:07.213\n  STEP: requiring image-registry to be available @ 11/10/25 18:49:07.338\n[INFO] Image-registry is available with 2 pod(s) running  STEP: ensuring no ClusterExtension and CRD from a previous run @ 11/10/25 18:49:07.469\n  STEP: ensuring no stale webhook configurations from previous tests @ 11/10/25 18:49:07.721\n  STEP: setting a unique value: \"b9zdkjw4\" @ 11/10/25 18:49:08.379\n  STEP: creating a new Namespace @ 11/10/25 18:49:08.379\n  STEP: waiting for builder serviceaccount in install-test-ns-b9zdkjw4 @ 11/10/25 18:49:08.513\n  STEP: waiting for deployer serviceaccount in install-test-ns-b9zdkjw4 @ 11/10/25 18:49:08.637\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:08.766\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:08.899\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:09.028\n  STEP: creating the operator tarball @ 11/10/25 18:49:09.156\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2087219100.tar\" @ 11/10/25 18:49:09.163\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:09.163\n  STEP: waiting for the build \"install-test-op-b9zdkjw4-1\" to finish @ 11/10/25 18:49:12.611\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:28.368\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:28.498\n  STEP: creating the catalog tarball @ 11/10/25 18:49:28.624\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1723780640.tar\" @ 11/10/25 18:49:28.625\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:28.625\n  STEP: waiting for the build \"install-test-cc-b9zdkjw4-1\" to finish @ 11/10/25 18:49:31.856\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:44.481\n  STEP: webhook bundle \"install-test-op-b9zdkjw4\" and catalog \"install-test-cc-b9zdkjw4\" built successfully in namespace \"install-test-ns-b9zdkjw4\" @ 11/10/25 18:49:47.87\n  STEP: installing the webhook operator in namespace webhook-operator-bngnd @ 11/10/25 18:49:47.87\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 11/10/25 18:49:48.252\n  STEP: waiting for the webhook operator to be installed @ 11/10/25 18:49:48.635\n  STEP: waiting for the webhook operator's service to be ready @ 11/10/25 18:49:54.993\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 11/10/25 18:49:55.115\n  STEP: setupWebhookOperator completed - ClusterExtension is ready for test to use @ 11/10/25 18:49:55.244\n  STEP: creating a webhook test resource that will be rejected by the validating webhook @ 11/10/25 18:49:55.244\n  STEP:  NOW cleaning up ClusterExtension (DeferCleanup executing)  @ 11/10/25 18:50:07.889\n  STEP: cleanup: deleting ClusterExtension webhook-operator-bngnd @ 11/10/25 18:50:07.889\n  STEP: waiting for ClusterExtension webhook-operator-bngnd to be fully deleted @ 11/10/25 18:50:08.093\n  STEP:  NOW cleaning up ClusterRoleBinding (DeferCleanup executing)  @ 11/10/25 18:50:11.337\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-bngnd-operator-crb @ 11/10/25 18:50:11.337\n  STEP:  NOW cleaning up ClusterExtension namespace (DeferCleanup executing)  @ 11/10/25 18:50:11.518\n  STEP: cleanup: deleting namespace webhook-operator-bngnd @ 11/10/25 18:50:11.518\n  STEP: waiting for namespace webhook-operator-bngnd to be fully deleted @ 11/10/25 18:50:11.644\n  STEP: deleting ClusterCatalog \"install-test-cc-b9zdkjw4\" @ 11/10/25 18:50:21.132\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1723780640.tar\" @ 11/10/25 18:50:21.265\n  STEP: deleting ImageStream \"install-test-cc-b9zdkjw4\" @ 11/10/25 18:50:21.266\n  STEP: deleting BuildConfig \"install-test-cc-b9zdkjw4\" @ 11/10/25 18:50:21.396\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2087219100.tar\" @ 11/10/25 18:50:21.535\n  STEP: deleting ImageStream \"install-test-op-b9zdkjw4\" @ 11/10/25 18:50:21.535\n  STEP: deleting BuildConfig \"install-test-op-b9zdkjw4\" @ 11/10/25 18:50:21.665\n  STEP: deleting image-puller RoleBinding \"install-test-rb-b9zdkjw4\" @ 11/10/25 18:50:21.798\n  STEP: deleting Namespace \"install-test-ns-b9zdkjw4\" @ 11/10/25 18:50:21.927\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should be tolerant to tls secret deletion [Serial]",
    "lifecycle": "blocking",
    "duration": 82834,
    "startTime": "2025-11-10 18:49:15.722028 UTC",
    "endTime": "2025-11-10 18:50:38.556382 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client @ 11/10/25 18:49:15.722\n  STEP: requiring OLMv1 capability on OpenShift @ 11/10/25 18:49:15.723\n  STEP: requiring image-registry to be available @ 11/10/25 18:49:15.854\n[INFO] Image-registry is available with 2 pod(s) running  STEP: ensuring no ClusterExtension and CRD from a previous run @ 11/10/25 18:49:15.985\n  STEP: ensuring no stale webhook configurations from previous tests @ 11/10/25 18:49:16.254\n  STEP: setting a unique value: \"nfxhqt5v\" @ 11/10/25 18:49:16.933\n  STEP: creating a new Namespace @ 11/10/25 18:49:16.933\n  STEP: waiting for builder serviceaccount in install-test-ns-nfxhqt5v @ 11/10/25 18:49:17.07\n  STEP: waiting for deployer serviceaccount in install-test-ns-nfxhqt5v @ 11/10/25 18:49:17.201\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:17.343\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:17.491\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:17.624\n  STEP: creating the operator tarball @ 11/10/25 18:49:17.76\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1986841214.tar\" @ 11/10/25 18:49:17.762\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:17.762\n  STEP: waiting for the build \"install-test-op-nfxhqt5v-1\" to finish @ 11/10/25 18:49:21.617\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:37.391\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:37.522\n  STEP: creating the catalog tarball @ 11/10/25 18:49:37.648\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3747130744.tar\" @ 11/10/25 18:49:37.65\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:37.65\n  STEP: waiting for the build \"install-test-cc-nfxhqt5v-1\" to finish @ 11/10/25 18:49:40.985\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:53.659\n  STEP: webhook bundle \"install-test-op-nfxhqt5v\" and catalog \"install-test-cc-nfxhqt5v\" built successfully in namespace \"install-test-ns-nfxhqt5v\" @ 11/10/25 18:49:57.117\n  STEP: installing the webhook operator in namespace webhook-operator-tds6w @ 11/10/25 18:49:57.117\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 11/10/25 18:49:57.605\n  STEP: waiting for the webhook operator to be installed @ 11/10/25 18:49:58.056\n  STEP: waiting for the webhook operator's service to be ready @ 11/10/25 18:50:13.84\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 11/10/25 18:50:13.966\n  STEP: setupWebhookOperator completed - ClusterExtension is ready for test to use @ 11/10/25 18:50:14.134\n  STEP: ensuring secret exists before deletion attempt @ 11/10/25 18:50:14.135\n  STEP: checking webhook is responsive through secret recreation after manual deletion @ 11/10/25 18:50:14.261\n  STEP: waiting for the webhook operator's service certificate secret to be recreated and populated @ 11/10/25 18:50:14.397\n  STEP:  NOW cleaning up ClusterExtension (DeferCleanup executing)  @ 11/10/25 18:50:27.331\n  STEP: cleanup: deleting ClusterExtension webhook-operator-tds6w @ 11/10/25 18:50:27.331\n  STEP: waiting for ClusterExtension webhook-operator-tds6w to be fully deleted @ 11/10/25 18:50:27.472\n  STEP:  NOW cleaning up ClusterRoleBinding (DeferCleanup executing)  @ 11/10/25 18:50:27.626\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-tds6w-operator-crb @ 11/10/25 18:50:27.626\n  STEP:  NOW cleaning up ClusterExtension namespace (DeferCleanup executing)  @ 11/10/25 18:50:27.856\n  STEP: cleanup: deleting namespace webhook-operator-tds6w @ 11/10/25 18:50:27.856\n  STEP: waiting for namespace webhook-operator-tds6w to be fully deleted @ 11/10/25 18:50:28.055\n  STEP: deleting ClusterCatalog \"install-test-cc-nfxhqt5v\" @ 11/10/25 18:50:37.599\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-3747130744.tar\" @ 11/10/25 18:50:37.736\n  STEP: deleting ImageStream \"install-test-cc-nfxhqt5v\" @ 11/10/25 18:50:37.737\n  STEP: deleting BuildConfig \"install-test-cc-nfxhqt5v\" @ 11/10/25 18:50:37.876\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1986841214.tar\" @ 11/10/25 18:50:38.009\n  STEP: deleting ImageStream \"install-test-op-nfxhqt5v\" @ 11/10/25 18:50:38.009\n  STEP: deleting BuildConfig \"install-test-op-nfxhqt5v\" @ 11/10/25 18:50:38.146\n  STEP: deleting image-puller RoleBinding \"install-test-rb-nfxhqt5v\" @ 11/10/25 18:50:38.284\n  STEP: deleting Namespace \"install-test-ns-nfxhqt5v\" @ 11/10/25 18:50:38.424\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should clean up webhooks when the extension is uninstalled [Serial]",
    "lifecycle": "blocking",
    "duration": 100520,
    "startTime": "2025-11-10 18:49:18.562783 UTC",
    "endTime": "2025-11-10 18:50:59.083145 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client @ 11/10/25 18:49:18.563\n  STEP: requiring OLMv1 capability on OpenShift @ 11/10/25 18:49:18.563\n  STEP: requiring image-registry to be available @ 11/10/25 18:49:18.735\n[INFO] Image-registry is available with 2 pod(s) running  STEP: ensuring no ClusterExtension and CRD from a previous run @ 11/10/25 18:49:18.862\n  STEP: ensuring no stale webhook configurations from previous tests @ 11/10/25 18:49:19.109\n  STEP: setting a unique value: \"4vsrxpgr\" @ 11/10/25 18:49:19.773\n  STEP: creating a new Namespace @ 11/10/25 18:49:19.773\n  STEP: waiting for builder serviceaccount in install-test-ns-4vsrxpgr @ 11/10/25 18:49:19.907\n  STEP: waiting for deployer serviceaccount in install-test-ns-4vsrxpgr @ 11/10/25 18:49:20.032\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:20.155\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:20.292\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:20.426\n  STEP: creating the operator tarball @ 11/10/25 18:49:20.557\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2042451948.tar\" @ 11/10/25 18:49:20.56\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:20.56\n  STEP: waiting for the build \"install-test-op-4vsrxpgr-1\" to finish @ 11/10/25 18:49:23.725\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:39.503\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:39.635\n  STEP: creating the catalog tarball @ 11/10/25 18:49:39.779\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2140960379.tar\" @ 11/10/25 18:49:39.78\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:39.78\n  STEP: waiting for the build \"install-test-cc-4vsrxpgr-1\" to finish @ 11/10/25 18:49:43.009\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:55.68\n  STEP: webhook bundle \"install-test-op-4vsrxpgr\" and catalog \"install-test-cc-4vsrxpgr\" built successfully in namespace \"install-test-ns-4vsrxpgr\" @ 11/10/25 18:49:59.072\n  STEP: installing the webhook operator in namespace webhook-operator-5q94c @ 11/10/25 18:49:59.072\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 11/10/25 18:49:59.452\n  STEP: waiting for the webhook operator to be installed @ 11/10/25 18:49:59.855\n  STEP: waiting for the webhook operator's service to be ready @ 11/10/25 18:50:34.427\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 11/10/25 18:50:34.553\n  STEP: setupWebhookOperator completed - ClusterExtension is ready for test to use @ 11/10/25 18:50:34.682\n  STEP: verifying that the webhook operator's webhooks are present @ 11/10/25 18:50:34.682\n  STEP: verifying that the webhook operator's mutating webhooks are present @ 11/10/25 18:50:34.815\n  STEP: uninstalling the ClusterExtension @ 11/10/25 18:50:34.941\n  STEP: waiting for ClusterExtension to be fully deleted @ 11/10/25 18:50:35.077\n  STEP: verifying that operator-created webhook configurations are cleaned up @ 11/10/25 18:50:44.612\n  STEP: verifying that mutating webhook configurations are cleaned up @ 11/10/25 18:50:44.746\n  STEP:  NOW cleaning up ClusterExtension (DeferCleanup executing)  @ 11/10/25 18:50:44.871\n  STEP: cleanup: deleting ClusterExtension webhook-operator-5q94c @ 11/10/25 18:50:44.871\n  STEP: waiting for ClusterExtension webhook-operator-5q94c to be fully deleted @ 11/10/25 18:50:44.996\n  STEP:  NOW cleaning up ClusterRoleBinding (DeferCleanup executing)  @ 11/10/25 18:50:45.128\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-5q94c-operator-crb @ 11/10/25 18:50:45.128\n  STEP:  NOW cleaning up ClusterExtension namespace (DeferCleanup executing)  @ 11/10/25 18:50:45.283\n  STEP: cleanup: deleting namespace webhook-operator-5q94c @ 11/10/25 18:50:45.283\n  STEP: waiting for namespace webhook-operator-5q94c to be fully deleted @ 11/10/25 18:50:45.438\n  STEP: deleting ClusterCatalog \"install-test-cc-4vsrxpgr\" @ 11/10/25 18:50:58.078\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2140960379.tar\" @ 11/10/25 18:50:58.267\n  STEP: deleting ImageStream \"install-test-cc-4vsrxpgr\" @ 11/10/25 18:50:58.268\n  STEP: deleting BuildConfig \"install-test-cc-4vsrxpgr\" @ 11/10/25 18:50:58.406\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2042451948.tar\" @ 11/10/25 18:50:58.539\n  STEP: deleting ImageStream \"install-test-op-4vsrxpgr\" @ 11/10/25 18:50:58.54\n  STEP: deleting BuildConfig \"install-test-op-4vsrxpgr\" @ 11/10/25 18:50:58.68\n  STEP: deleting image-puller RoleBinding \"install-test-rb-4vsrxpgr\" @ 11/10/25 18:50:58.818\n  STEP: deleting Namespace \"install-test-ns-4vsrxpgr\" @ 11/10/25 18:50:58.945\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should have a working conversion webhook [Serial]",
    "lifecycle": "blocking",
    "duration": 128178,
    "startTime": "2025-11-10 18:49:12.115987 UTC",
    "endTime": "2025-11-10 18:51:20.294197 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client @ 11/10/25 18:49:12.116\n  STEP: requiring OLMv1 capability on OpenShift @ 11/10/25 18:49:12.116\n  STEP: requiring image-registry to be available @ 11/10/25 18:49:12.242\n[INFO] Image-registry is available with 2 pod(s) running  STEP: ensuring no ClusterExtension and CRD from a previous run @ 11/10/25 18:49:12.39\n  STEP: ensuring no stale webhook configurations from previous tests @ 11/10/25 18:49:12.636\n  STEP: setting a unique value: \"z7dnkqw7\" @ 11/10/25 18:49:13.428\n  STEP: creating a new Namespace @ 11/10/25 18:49:13.428\n  STEP: waiting for builder serviceaccount in install-test-ns-z7dnkqw7 @ 11/10/25 18:49:13.551\n  STEP: waiting for deployer serviceaccount in install-test-ns-z7dnkqw7 @ 11/10/25 18:49:13.667\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:13.79\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:13.924\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:14.07\n  STEP: creating the operator tarball @ 11/10/25 18:49:14.2\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2952941879.tar\" @ 11/10/25 18:49:14.204\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:14.204\n  STEP: waiting for the build \"install-test-op-z7dnkqw7-1\" to finish @ 11/10/25 18:49:17.751\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:33.498\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:33.637\n  STEP: creating the catalog tarball @ 11/10/25 18:49:33.774\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2912632880.tar\" @ 11/10/25 18:49:33.776\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:33.776\n  STEP: waiting for the build \"install-test-cc-z7dnkqw7-1\" to finish @ 11/10/25 18:49:36.843\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:49.501\n  STEP: webhook bundle \"install-test-op-z7dnkqw7\" and catalog \"install-test-cc-z7dnkqw7\" built successfully in namespace \"install-test-ns-z7dnkqw7\" @ 11/10/25 18:49:52.884\n  STEP: installing the webhook operator in namespace webhook-operator-8hxqf @ 11/10/25 18:49:52.884\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 11/10/25 18:49:53.263\n  STEP: waiting for the webhook operator to be installed @ 11/10/25 18:49:53.64\n  STEP: waiting for the webhook operator's service to be ready @ 11/10/25 18:50:46.974\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 11/10/25 18:50:47.093\n  STEP: setupWebhookOperator completed - ClusterExtension is ready for test to use @ 11/10/25 18:50:47.215\n  STEP: creating a conversion webhook test resource @ 11/10/25 18:50:47.215\n  STEP: getting the created resource in v2 schema @ 11/10/25 18:50:59.87\n  STEP: validating the resource spec @ 11/10/25 18:51:00.002\n  STEP:  NOW cleaning up ClusterExtension (DeferCleanup executing)  @ 11/10/25 18:51:00.002\n  STEP: cleanup: deleting ClusterExtension webhook-operator-8hxqf @ 11/10/25 18:51:00.002\n  STEP: waiting for ClusterExtension webhook-operator-8hxqf to be fully deleted @ 11/10/25 18:51:00.131\n  STEP:  NOW cleaning up ClusterRoleBinding (DeferCleanup executing)  @ 11/10/25 18:51:09.618\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-8hxqf-operator-crb @ 11/10/25 18:51:09.618\n  STEP:  NOW cleaning up ClusterExtension namespace (DeferCleanup executing)  @ 11/10/25 18:51:09.751\n  STEP: cleanup: deleting namespace webhook-operator-8hxqf @ 11/10/25 18:51:09.751\n  STEP: waiting for namespace webhook-operator-8hxqf to be fully deleted @ 11/10/25 18:51:09.892\n  STEP: deleting ClusterCatalog \"install-test-cc-z7dnkqw7\" @ 11/10/25 18:51:19.375\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2912632880.tar\" @ 11/10/25 18:51:19.505\n  STEP: deleting ImageStream \"install-test-cc-z7dnkqw7\" @ 11/10/25 18:51:19.505\n  STEP: deleting BuildConfig \"install-test-cc-z7dnkqw7\" @ 11/10/25 18:51:19.642\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-2952941879.tar\" @ 11/10/25 18:51:19.775\n  STEP: deleting ImageStream \"install-test-op-z7dnkqw7\" @ 11/10/25 18:51:19.776\n  STEP: deleting BuildConfig \"install-test-op-z7dnkqw7\" @ 11/10/25 18:51:19.911\n  STEP: deleting image-puller RoleBinding \"install-test-rb-z7dnkqw7\" @ 11/10/25 18:51:20.045\n  STEP: deleting Namespace \"install-test-ns-z7dnkqw7\" @ 11/10/25 18:51:20.169\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should have a working mutating webhook [Serial]",
    "lifecycle": "blocking",
    "duration": 148188,
    "startTime": "2025-11-10 18:49:10.549473 UTC",
    "endTime": "2025-11-10 18:51:38.738107 UTC",
    "result": "passed",
    "output": "  STEP: initializing Kubernetes client @ 11/10/25 18:49:10.549\n  STEP: requiring OLMv1 capability on OpenShift @ 11/10/25 18:49:10.55\n  STEP: requiring image-registry to be available @ 11/10/25 18:49:10.677\n[INFO] Image-registry is available with 2 pod(s) running  STEP: ensuring no ClusterExtension and CRD from a previous run @ 11/10/25 18:49:10.805\n  STEP: ensuring no stale webhook configurations from previous tests @ 11/10/25 18:49:11.085\n  STEP: setting a unique value: \"xgq5h79l\" @ 11/10/25 18:49:11.755\n  STEP: creating a new Namespace @ 11/10/25 18:49:11.755\n  STEP: waiting for builder serviceaccount in install-test-ns-xgq5h79l @ 11/10/25 18:49:11.883\n  STEP: waiting for deployer serviceaccount in install-test-ns-xgq5h79l @ 11/10/25 18:49:12.006\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:12.129\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:12.265\n  STEP: creating the operator ImageStream @ 11/10/25 18:49:12.402\n  STEP: creating the operator tarball @ 11/10/25 18:49:12.534\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1436542704.tar\" @ 11/10/25 18:49:12.536\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:49:12.536\n  STEP: waiting for the build \"install-test-op-xgq5h79l-1\" to finish @ 11/10/25 18:49:16.413\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:32.215\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:32.354\n  STEP: creating the catalog tarball @ 11/10/25 18:49:32.482\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-350780021.tar\" @ 11/10/25 18:49:32.484\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:32.484\n  STEP: waiting for the build \"install-test-cc-xgq5h79l-1\" to finish @ 11/10/25 18:49:35.897\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:48.551\n  STEP: webhook bundle \"install-test-op-xgq5h79l\" and catalog \"install-test-cc-xgq5h79l\" built successfully in namespace \"install-test-ns-xgq5h79l\" @ 11/10/25 18:49:51.939\n  STEP: installing the webhook operator in namespace webhook-operator-sq2jq @ 11/10/25 18:49:51.939\n  STEP: creating a ClusterRoleBinding to cluster-admin for the webhook operator @ 11/10/25 18:49:52.353\n  STEP: waiting for the webhook operator to be installed @ 11/10/25 18:49:52.766\n  STEP: waiting for the webhook operator's service to be ready @ 11/10/25 18:51:11.069\n  STEP: waiting for the webhook operator's service certificate secret to exist and be populated @ 11/10/25 18:51:11.194\n  STEP: setupWebhookOperator completed - ClusterExtension is ready for test to use @ 11/10/25 18:51:11.323\n  STEP: creating a valid webhook @ 11/10/25 18:51:11.323\n  STEP: getting the created resource in v1 schema @ 11/10/25 18:51:24.154\n  STEP: validating the resource spec @ 11/10/25 18:51:24.281\n  STEP:  NOW cleaning up ClusterExtension (DeferCleanup executing)  @ 11/10/25 18:51:24.281\n  STEP: cleanup: deleting ClusterExtension webhook-operator-sq2jq @ 11/10/25 18:51:24.281\n  STEP: waiting for ClusterExtension webhook-operator-sq2jq to be fully deleted @ 11/10/25 18:51:24.484\n  STEP:  NOW cleaning up ClusterRoleBinding (DeferCleanup executing)  @ 11/10/25 18:51:27.757\n  STEP: cleanup: deleting ClusterRoleBinding webhook-operator-sq2jq-operator-crb @ 11/10/25 18:51:27.757\n  STEP:  NOW cleaning up ClusterExtension namespace (DeferCleanup executing)  @ 11/10/25 18:51:27.894\n  STEP: cleanup: deleting namespace webhook-operator-sq2jq @ 11/10/25 18:51:27.894\n  STEP: waiting for namespace webhook-operator-sq2jq to be fully deleted @ 11/10/25 18:51:28.066\n  STEP: deleting ClusterCatalog \"install-test-cc-xgq5h79l\" @ 11/10/25 18:51:37.569\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-350780021.tar\" @ 11/10/25 18:51:37.706\n  STEP: deleting ImageStream \"install-test-cc-xgq5h79l\" @ 11/10/25 18:51:37.707\n  STEP: deleting BuildConfig \"install-test-cc-xgq5h79l\" @ 11/10/25 18:51:37.843\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1436542704.tar\" @ 11/10/25 18:51:37.983\n  STEP: deleting ImageStream \"install-test-op-xgq5h79l\" @ 11/10/25 18:51:37.984\n  STEP: deleting BuildConfig \"install-test-op-xgq5h79l\" @ 11/10/25 18:51:38.205\n  STEP: deleting image-puller RoleBinding \"install-test-rb-xgq5h79l\" @ 11/10/25 18:51:38.408\n  STEP: deleting Namespace \"install-test-ns-xgq5h79l\" @ 11/10/25 18:51:38.613\n"
  },
  {
    "name": "[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 operator installation support for ownNamespace and single namespace watch mode with operator should install cluster extensions successfully in both watch modes",
    "lifecycle": "blocking",
    "duration": 173045,
    "startTime": "2025-11-10 18:48:57.175936 UTC",
    "endTime": "2025-11-10 18:51:50.221238 UTC",
    "result": "passed",
    "output": "  STEP: checking if OpenShift is available for tests @ 11/10/25 18:48:57.176\n[INFO] Image-registry is available with 2 pod(s) running  STEP: using singleown operator image: quay.io/olmtest/webhook-operator:v0.0.5 @ 11/10/25 18:48:57.441\n  STEP: building singleown operator assets for singleNamespace watch mode scenario: image=quay.io/olmtest/webhook-operator:v0.0.5, CRD suffix=vsbb, package=singleown-operator-both-vsbb @ 11/10/25 18:48:57.441\n  STEP: setting a unique value: \"g6z9c8bd\" @ 11/10/25 18:48:57.562\n  STEP: creating a new Namespace @ 11/10/25 18:48:57.562\n  STEP: waiting for builder serviceaccount in install-test-ns-g6z9c8bd @ 11/10/25 18:48:57.695\n  STEP: waiting for deployer serviceaccount in install-test-ns-g6z9c8bd @ 11/10/25 18:48:57.816\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:48:57.943\n  STEP: creating the operator BuildConfig @ 11/10/25 18:48:58.084\n  STEP: creating the operator ImageStream @ 11/10/25 18:48:58.221\n  STEP: creating the operator tarball @ 11/10/25 18:48:58.358\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-189507665.tar\" @ 11/10/25 18:48:58.361\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:48:58.361\n  STEP: waiting for the build \"install-test-op-g6z9c8bd-1\" to finish @ 11/10/25 18:49:02.173\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:49:17.954\n  STEP: creating the catalog ImageStream @ 11/10/25 18:49:18.087\n  STEP: creating the catalog tarball @ 11/10/25 18:49:18.221\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1993451902.tar\" @ 11/10/25 18:49:18.223\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:49:18.223\n  STEP: waiting for the build \"install-test-cc-g6z9c8bd-1\" to finish @ 11/10/25 18:49:21.616\n  STEP: creating the ClusterCatalog @ 11/10/25 18:49:34.248\n  STEP: singleown bundle \"install-test-op-g6z9c8bd\" and catalog \"install-test-cc-g6z9c8bd\" built successfully in namespace \"install-test-ns-g6z9c8bd\" for singleNamespace watch mode scenario @ 11/10/25 18:49:37.631\n  STEP: ensuring no ClusterExtension for singleown-operator-both-vsbb before singleNamespace watch mode scenario @ 11/10/25 18:49:37.631\n  STEP: creating namespace olmv1-webhook-bothns-singlens-bx6x for singleNamespace watch mode tests @ 11/10/25 18:49:37.881\n  STEP: creating namespace olmv1-webhook-bothns-singlens-bx6x-watch for watch namespace in singleNamespace watch mode scenario @ 11/10/25 18:49:38.018\n  STEP: creating ServiceAccount install-webhook-bothns-singlens-sa-bx6x for singleNamespace watch mode scenario @ 11/10/25 18:49:38.149\n  STEP: creating ClusterRoleBinding install-webhook-bothns-singlens-crb-bx6x for singleNamespace watch mode scenario @ 11/10/25 18:49:38.395\n  STEP: creating ClusterExtension install-webhook-bothns-singlens-ce-bx6x for singleNamespace watch mode scenario @ 11/10/25 18:49:38.643\n  STEP: waiting for the ClusterExtension install-webhook-bothns-singlens-ce-bx6x to be installed for singleNamespace watch mode scenario @ 11/10/25 18:49:38.768\n  STEP: verifying the operator deployment watch scope annotation for singleNamespace watch mode scenario @ 11/10/25 18:49:42.015\n  STEP: cleaning up resources created for singleNamespace watch mode scenario to allow next scenario @ 11/10/25 18:49:42.15\n  STEP: deleting ClusterExtension install-webhook-bothns-singlens-ce-bx6x (package: singleown-operator-both-vsbb) @ 11/10/25 18:49:42.432\n  STEP: waiting for namespace olmv1-webhook-bothns-singlens-bx6x to be fully deleted before next scenario @ 11/10/25 18:49:46.556\n  STEP: waiting for namespace olmv1-webhook-bothns-singlens-bx6x-watch to be fully deleted before next scenario @ 11/10/25 18:49:59.185\n  STEP: building singleown operator assets for ownNamespace watch mode scenario: image=quay.io/olmtest/webhook-operator:v0.0.5, CRD suffix=xtlz, package=singleown-operator-both-xtlz @ 11/10/25 18:49:59.306\n  STEP: setting a unique value: \"jbssvfvm\" @ 11/10/25 18:49:59.432\n  STEP: creating a new Namespace @ 11/10/25 18:49:59.432\n  STEP: waiting for builder serviceaccount in install-test-ns-jbssvfvm @ 11/10/25 18:49:59.558\n  STEP: waiting for deployer serviceaccount in install-test-ns-jbssvfvm @ 11/10/25 18:49:59.687\n  STEP: applying image-puller RoleBinding @ 11/10/25 18:49:59.811\n  STEP: creating the operator BuildConfig @ 11/10/25 18:49:59.949\n  STEP: creating the operator ImageStream @ 11/10/25 18:50:00.078\n  STEP: creating the operator tarball @ 11/10/25 18:50:00.205\n  STEP: created operator tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-265098950.tar\" @ 11/10/25 18:50:00.208\n  STEP: starting the operator build via RAW URL @ 11/10/25 18:50:00.208\n  STEP: waiting for the build \"install-test-op-jbssvfvm-1\" to finish @ 11/10/25 18:50:03.272\n  STEP: creating the catalog BuildConfig @ 11/10/25 18:50:19.012\n  STEP: creating the catalog ImageStream @ 11/10/25 18:50:19.145\n  STEP: creating the catalog tarball @ 11/10/25 18:50:19.355\n  STEP: created catalog tarball \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-694909351.tar\" @ 11/10/25 18:50:19.358\n  STEP: starting the catalog build via RAW URL @ 11/10/25 18:50:19.358\n  STEP: waiting for the build \"install-test-cc-jbssvfvm-1\" to finish @ 11/10/25 18:50:22.478\n  STEP: creating the ClusterCatalog @ 11/10/25 18:50:35.129\n  STEP: singleown bundle \"install-test-op-jbssvfvm\" and catalog \"install-test-cc-jbssvfvm\" built successfully in namespace \"install-test-ns-jbssvfvm\" for ownNamespace watch mode scenario @ 11/10/25 18:50:38.506\n  STEP: ensuring no ClusterExtension for singleown-operator-both-xtlz before ownNamespace watch mode scenario @ 11/10/25 18:50:38.506\n  STEP: creating namespace olmv1-webhook-bothns-ownns-rhc4 for ownNamespace watch mode tests @ 11/10/25 18:50:38.761\n  STEP: creating ServiceAccount install-webhook-bothns-ownns-sa-rhc4 for ownNamespace watch mode scenario @ 11/10/25 18:50:38.891\n  STEP: creating ClusterRoleBinding install-webhook-bothns-ownns-crb-rhc4 for ownNamespace watch mode scenario @ 11/10/25 18:50:39.14\n  STEP: creating ClusterExtension install-webhook-bothns-ownns-ce-rhc4 for ownNamespace watch mode scenario @ 11/10/25 18:50:39.382\n  STEP: waiting for the ClusterExtension install-webhook-bothns-ownns-ce-rhc4 to be installed for ownNamespace watch mode scenario @ 11/10/25 18:50:39.509\n  STEP: verifying the operator deployment watch scope annotation for ownNamespace watch mode scenario @ 11/10/25 18:51:32.783\n  STEP: cleaning up resources created for ownNamespace watch mode scenario to allow next scenario @ 11/10/25 18:51:32.914\n  STEP: deleting ClusterExtension install-webhook-bothns-ownns-ce-rhc4 (package: singleown-operator-both-xtlz) @ 11/10/25 18:51:33.224\n  STEP: waiting for namespace olmv1-webhook-bothns-ownns-rhc4 to be fully deleted before next scenario @ 11/10/25 18:51:37.13\n  STEP: cleanup: deleting ClusterExtension install-webhook-bothns-ownns-ce-rhc4 @ 11/10/25 18:51:46.612\n  STEP: cleanup: deleting ClusterRoleBinding install-webhook-bothns-ownns-crb-rhc4 @ 11/10/25 18:51:47.076\n  STEP: cleanup: deleting ServiceAccount install-webhook-bothns-ownns-sa-rhc4 in namespace olmv1-webhook-bothns-ownns-rhc4 @ 11/10/25 18:51:47.2\n  STEP: cleanup: deleting install namespace olmv1-webhook-bothns-ownns-rhc4 @ 11/10/25 18:51:47.321\n  STEP: deleting ClusterCatalog \"install-test-cc-jbssvfvm\" @ 11/10/25 18:51:47.446\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-694909351.tar\" @ 11/10/25 18:51:47.581\n  STEP: deleting ImageStream \"install-test-cc-jbssvfvm\" @ 11/10/25 18:51:47.581\n  STEP: deleting BuildConfig \"install-test-cc-jbssvfvm\" @ 11/10/25 18:51:47.72\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-265098950.tar\" @ 11/10/25 18:51:47.851\n  STEP: deleting ImageStream \"install-test-op-jbssvfvm\" @ 11/10/25 18:51:47.851\n  STEP: deleting BuildConfig \"install-test-op-jbssvfvm\" @ 11/10/25 18:51:47.98\n  STEP: deleting image-puller RoleBinding \"install-test-rb-jbssvfvm\" @ 11/10/25 18:51:48.109\n  STEP: deleting Namespace \"install-test-ns-jbssvfvm\" @ 11/10/25 18:51:48.239\n  STEP: cleanup: deleting ClusterExtension install-webhook-bothns-singlens-ce-bx6x @ 11/10/25 18:51:48.364\n  STEP: cleanup: deleting ClusterRoleBinding install-webhook-bothns-singlens-crb-bx6x @ 11/10/25 18:51:48.766\n  STEP: cleanup: deleting ServiceAccount install-webhook-bothns-singlens-sa-bx6x in namespace olmv1-webhook-bothns-singlens-bx6x @ 11/10/25 18:51:48.893\n  STEP: cleanup: deleting watch namespace olmv1-webhook-bothns-singlens-bx6x-watch @ 11/10/25 18:51:49.022\n  STEP: cleanup: deleting install namespace olmv1-webhook-bothns-singlens-bx6x @ 11/10/25 18:51:49.14\n  STEP: deleting ClusterCatalog \"install-test-cc-g6z9c8bd\" @ 11/10/25 18:51:49.257\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-1993451902.tar\" @ 11/10/25 18:51:49.389\n  STEP: deleting ImageStream \"install-test-cc-g6z9c8bd\" @ 11/10/25 18:51:49.39\n  STEP: deleting BuildConfig \"install-test-cc-g6z9c8bd\" @ 11/10/25 18:51:49.572\n  STEP: deleting file \"/var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/bundle-189507665.tar\" @ 11/10/25 18:51:49.704\n  STEP: deleting ImageStream \"install-test-op-g6z9c8bd\" @ 11/10/25 18:51:49.705\n  STEP: deleting BuildConfig \"install-test-op-g6z9c8bd\" @ 11/10/25 18:51:49.831\n  STEP: deleting image-puller RoleBinding \"install-test-rb-g6z9c8bd\" @ 11/10/25 18:51:49.964\n  STEP: deleting Namespace \"install-test-ns-g6z9c8bd\" @ 11/10/25 18:51:50.094\n"
  }
```

