### PR TITLE
[WIP] TRT-XXXX: Revert #542 "OPRUN-4212: [OTE]: Add webhook cleanup validation on extension uninstall"

### DIFF
--- a/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
+++ b/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
@@ -620,15 +620,5 @@
     "source": "openshift:payload:olmv1",
     "lifecycle": "blocking",
     "environmentSelector": {}
-  },
-  {
-    "name": "[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA] OLMv1 operator with webhooks should clean up webhooks when the extension is uninstalled [Serial]",
-    "labels": {},
-    "resources": {
-      "isolation": {}
-    },
-    "source": "openshift:payload:olmv1",
-    "lifecycle": "blocking",
-    "environmentSelector": {}
   }
 ]

--- a/openshift/tests-extension/pkg/env/cluster.go
+++ b/openshift/tests-extension/pkg/env/cluster.go
@@ -11,7 +11,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -89,7 +88,6 @@ func initTestEnv() *TestEnv {
 	utilruntime.Must(rbacv1.AddToScheme(scheme))
 	utilruntime.Must(batchv1.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
-	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(olmv1.AddToScheme(scheme))
 
 	if isOcp {


### PR DESCRIPTION

Reverts #542 ; tracked by TRT-XXXX

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

webhook-related tests are failing payloads

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Verify tests pass 10x on something like periodic-ci-openshift-release-master-ci-4.21-e2e-azure-ovn-techpreview
```

CC: @camilamacedo86

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
