### PR TITLE
OCPBUGS-62517: enable downstream pdb and update replicas to meet MCO drain

### DIFF
--- a/hack/test/pre-upgrade-setup.sh
+++ b/hack/test/pre-upgrade-setup.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -euo pipefail
+
+help="pre-upgrade-setup.sh is used to create some basic resources
+which will later be used in upgrade testing.
+
+Usage:
+  pre-upgrade-setup.sh [TEST_CATALOG_IMG] [TEST_CLUSTER_CATALOG_NAME] [TEST_CLUSTER_EXTENSION_NAME]
+"
+
+if [[ "$#" -ne 3 ]]; then
+  echo "Illegal number of arguments passed"
+  echo "${help}"
+  exit 1
+fi
+
+TEST_CATALOG_IMG=$1
+TEST_CLUSTER_CATALOG_NAME=$2
+TEST_CLUSTER_EXTENSION_NAME=$3
+
+kubectl apply -f - << EOF
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: ${TEST_CLUSTER_CATALOG_NAME}
+spec:
+  source:
+    type: Image
+    image:
+      ref: ${TEST_CATALOG_IMG}
+      pollIntervalMinutes: 1440
+EOF
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: upgrade-e2e
+  namespace: default
+EOF
+
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: upgrade-e2e
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    - "secrets"
+    - "services"
+    - "serviceaccounts"
+    verbs:
+    - "create"
+    - "update"
+    - "patch"
+    - "delete"
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "apps"
+    resources:
+    - "deployments"
+    verbs:
+    - "create"
+    - "update"
+    - "patch"
+    - "delete"
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "apiextensions.k8s.io"
+    resources:
+    - "customresourcedefinitions"
+    verbs:
+    - "create"
+    - "update"
+    - "patch"
+    - "delete"
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "rbac.authorization.k8s.io"
+    resources:
+    - "clusterroles"
+    - "clusterrolebindings"
+    - "roles"
+    - "rolebindings"
+    verbs:
+    - "create"
+    - "update"
+    - "patch"
+    - "delete"
+    - "get"
+    - "list"
+    - "watch"
+    - "bind"
+    - "escalate"
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - "olm.operatorframework.io"
+    resources:
+    - "clusterextensions/finalizers"
+    verbs:
+    - "update"
+    resourceNames:
+    - "${TEST_CLUSTER_EXTENSION_NAME}"
+EOF
+
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: upgrade-e2e
+subjects:
+  - kind: ServiceAccount
+    name: upgrade-e2e
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: upgrade-e2e
+EOF
+
+kubectl apply -f - << EOF
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: ${TEST_CLUSTER_EXTENSION_NAME}
+spec:
+  namespace: default
+  serviceAccount:
+    name: upgrade-e2e
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: test
+      version: 1.0.0
+EOF
+
+kubectl wait --for=condition=Serving --timeout=5m clustercatalog/${TEST_CLUSTER_CATALOG_NAME}
+kubectl wait --for=condition=Installed --timeout=5m clusterextension/${TEST_CLUSTER_EXTENSION_NAME}

--- a/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-catalogd-controller-manager.yml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Values.namespaces.olmv1.name }}
 spec:
   minReadySeconds: 5
-  replicas: 1
+  replicas: {{ .Values.options.catalogd.deployment.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
+++ b/helm/olmv1/templates/deployment-olmv1-system-operator-controller-controller-manager.yml
@@ -11,7 +11,7 @@ metadata:
   name: operator-controller-controller-manager
   namespace: {{ .Values.namespaces.olmv1.name }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.options.operatorController.deployment.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm/olmv1/values.yaml
+++ b/helm/olmv1/values.yaml
@@ -8,6 +8,7 @@ options:
     enabled: true
     deployment:
       image: quay.io/operator-framework/operator-controller:devel
+      replicas: 2
       extraArguments: []
     features:
       enabled: []
@@ -19,6 +20,7 @@ options:
     enabled: true
     deployment:
       image: quay.io/operator-framework/catalogd:devel
+      replicas: 2
       extraArguments: []
     features:
       enabled: []

--- a/manifests/experimental-e2e.yaml
+++ b/manifests/experimental-e2e.yaml
@@ -2535,7 +2535,7 @@ metadata:
   namespace: olmv1-system
 spec:
   minReadySeconds: 5
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -2686,7 +2686,7 @@ metadata:
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/manifests/experimental.yaml
+++ b/manifests/experimental.yaml
@@ -2455,7 +2455,7 @@ metadata:
   namespace: olmv1-system
 spec:
   minReadySeconds: 5
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -2593,7 +2593,7 @@ metadata:
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/manifests/standard-e2e.yaml
+++ b/manifests/standard-e2e.yaml
@@ -1778,7 +1778,7 @@ metadata:
   namespace: olmv1-system
 spec:
   minReadySeconds: 5
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -1928,7 +1928,7 @@ metadata:
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/manifests/standard.yaml
+++ b/manifests/standard.yaml
@@ -1698,7 +1698,7 @@ metadata:
   namespace: olmv1-system
 spec:
   minReadySeconds: 5
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -1835,7 +1835,7 @@ metadata:
   name: operator-controller-controller-manager
   namespace: olmv1-system
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/openshift/catalogd/manifests-experimental.yaml
+++ b/openshift/catalogd/manifests-experimental.yaml
@@ -65,6 +65,23 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: catalogd-controller-manager
+  namespace: openshift-catalogd
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount
@@ -825,7 +842,7 @@ metadata:
   namespace: openshift-catalogd
 spec:
   minReadySeconds: 5
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/openshift/catalogd/manifests.yaml
+++ b/openshift/catalogd/manifests.yaml
@@ -65,6 +65,23 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-catalogd.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: catalogd-controller-manager
+  namespace: openshift-catalogd
+  labels:
+    app.kubernetes.io/name: catalogd
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: standard
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: catalogd-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount
@@ -825,7 +842,7 @@ metadata:
   namespace: openshift-catalogd
 spec:
   minReadySeconds: 5
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/openshift/helm/catalogd.yaml
+++ b/openshift/helm/catalogd.yaml
@@ -9,7 +9,7 @@ options:
     deployment:
       image: ${CATALOGD_IMAGE}
     podDisruptionBudget:
-      enabled: false
+      enabled: true
   operatorController:
     enabled: false
   openshift:

--- a/openshift/helm/operator-controller.yaml
+++ b/openshift/helm/operator-controller.yaml
@@ -9,7 +9,7 @@ options:
     deployment:
       image: ${OPERATOR_CONTROLLER_IMAGE}
     podDisruptionBudget:
-      enabled: false
+      enabled: true
   catalogd:
     enabled: false
   openshift:

--- a/openshift/operator-controller/manifests-experimental.yaml
+++ b/openshift/operator-controller/manifests-experimental.yaml
@@ -61,6 +61,23 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: operator-controller-controller-manager
+  namespace: openshift-operator-controller
+  labels:
+    app.kubernetes.io/name: operator-controller
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: experimental
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount
@@ -1184,7 +1201,7 @@ metadata:
   name: operator-controller-controller-manager
   namespace: openshift-operator-controller
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/openshift/operator-controller/manifests.yaml
+++ b/openshift/operator-controller/manifests.yaml
@@ -61,6 +61,23 @@ spec:
     - Ingress
     - Egress
 ---
+# Source: olmv1/templates/poddisruptionbudget-olmv1-system-operator-controller.yml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: operator-controller-controller-manager
+  namespace: openshift-operator-controller
+  labels:
+    app.kubernetes.io/name: operator-controller
+    app.kubernetes.io/part-of: olm
+  annotations:
+    olm.operatorframework.io/feature-set: standard
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: operator-controller-controller-manager
+---
 # Source: olmv1/templates/serviceaccount-olmv1-system-common-controller-manager.yml
 apiVersion: v1
 kind: ServiceAccount
@@ -1056,7 +1073,7 @@ metadata:
   name: operator-controller-controller-manager
   namespace: openshift-operator-controller
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -34,7 +34,15 @@ var (
 )
 
 const (
-	pollDuration         = time.Minute
+	pollDuration = time.Minute
+	// catalogPollDuration is used for catalog operations (unpacking, serving) which involve
+	// I/O-bound operations like pulling OCI images and unpacking catalog content.
+	catalogPollDuration = 3 * time.Minute
+	// extendedPollDuration is used for operations that involve pod restarts (like upgrades)
+	// or webhook installations with cert-manager. In the worst case of a pod crash during upgrade,
+	// leader election can take up to 163 seconds (LeaseDuration: 137s + RetryPeriod: 26s).
+	// With LeaderElectionReleaseOnCancel: true, graceful shutdowns only take ~26s (RetryPeriod).
+	extendedPollDuration = 5 * time.Minute
 	pollInterval         = time.Second
 	testCatalogName      = "test-catalog"
 	testCatalogRefEnvVar = "CATALOG_IMG"
@@ -268,7 +276,7 @@ func ValidateCatalogUnpackWithName(t *testing.T, catalogName string) {
 		require.NotNil(ct, cond)
 		require.Equal(ct, metav1.ConditionTrue, cond.Status)
 		require.Equal(ct, ocv1.ReasonSucceeded, cond.Reason)
-	}, pollDuration, pollInterval)
+	}, catalogPollDuration, pollInterval)
 
 	t.Log("Checking that catalog has the expected metadata label")
 	require.NotNil(t, catalog.Labels)
@@ -283,13 +291,17 @@ func ValidateCatalogUnpackWithName(t *testing.T, catalogName string) {
 		require.NotNil(ct, cond)
 		require.Equal(ct, metav1.ConditionTrue, cond.Status)
 		require.Equal(ct, ocv1.ReasonAvailable, cond.Reason)
-	}, pollDuration, pollInterval)
+	}, catalogPollDuration, pollInterval)
 }
 
 func EnsureNoExtensionResources(t *testing.T, clusterExtensionName string) {
 	ls := labels.Set{"olm.operatorframework.io/owner-name": clusterExtensionName}
 
-	// CRDs may take an extra long time to be deleted, and may run into the following error:
+	// Use catalogPollDuration (3 min) for CRD cleanup operations.
+	// CRDs may take extra time to delete due to finalizers and instance cleanup.
+	cleanupTimeout := catalogPollDuration
+
+	// CRDs may take extra time to be deleted, and may run into the following error:
 	// Condition=Terminating Status=True Reason=InstanceDeletionFailed Message="could not list instances: storage is (re)initializing"
 	t.Logf("By waiting for CustomResourceDefinitions of %q to be deleted", clusterExtensionName)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -297,7 +309,7 @@ func EnsureNoExtensionResources(t *testing.T, clusterExtensionName string) {
 		err := c.List(context.Background(), list, client.MatchingLabelsSelector{Selector: ls.AsSelector()})
 		require.NoError(ct, err)
 		require.Empty(ct, list.Items)
-	}, 5*pollDuration, pollInterval)
+	}, cleanupTimeout, pollInterval)
 
 	t.Logf("By waiting for ClusterRoleBindings of %q to be deleted", clusterExtensionName)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -305,7 +317,7 @@ func EnsureNoExtensionResources(t *testing.T, clusterExtensionName string) {
 		err := c.List(context.Background(), list, client.MatchingLabelsSelector{Selector: ls.AsSelector()})
 		require.NoError(ct, err)
 		require.Empty(ct, list.Items)
-	}, 2*pollDuration, pollInterval)
+	}, cleanupTimeout, pollInterval)
 
 	t.Logf("By waiting for ClusterRoles of %q to be deleted", clusterExtensionName)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -313,7 +325,7 @@ func EnsureNoExtensionResources(t *testing.T, clusterExtensionName string) {
 		err := c.List(context.Background(), list, client.MatchingLabelsSelector{Selector: ls.AsSelector()})
 		require.NoError(ct, err)
 		require.Empty(ct, list.Items)
-	}, 2*pollDuration, pollInterval)
+	}, cleanupTimeout, pollInterval)
 }
 
 func TestCleanup(t *testing.T, cat *ocv1.ClusterCatalog, clusterExtension *ocv1.ClusterExtension, sa *corev1.ServiceAccount, ns *corev1.Namespace) {
@@ -348,10 +360,12 @@ func TestCleanup(t *testing.T, cat *ocv1.ClusterCatalog, clusterExtension *ocv1.
 	if ns != nil {
 		t.Logf("By deleting Namespace %q", ns.Name)
 		require.NoError(t, c.Delete(context.Background(), ns))
+		// Namespace deletion may take longer as it needs to delete all resources within it.
+		// Use extendedPollDuration to allow sufficient time for graceful cleanup.
 		require.Eventually(t, func() bool {
 			err := c.Get(context.Background(), types.NamespacedName{Name: ns.Name}, &corev1.Namespace{})
 			return errors.IsNotFound(err)
-		}, pollDuration, pollInterval)
+		}, extendedPollDuration, pollInterval)
 	}
 }
 

--- a/test/upgrade-e2e/post_upgrade_test.go
+++ b/test/upgrade-e2e/post_upgrade_test.go
@@ -1,0 +1,348 @@
+package upgradee2e
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	testutil "github.com/operator-framework/operator-controller/internal/shared/util/test"
+)
+
+const (
+	artifactName = "operator-controller-upgrade-e2e"
+	container    = "manager"
+	// pollDuration is set to 3 minutes for upgrade tests because upgrades cause pod restarts.
+	// With LeaderElectionReleaseOnCancel: true, graceful shutdowns take ~26s (RetryPeriod).
+	// In the worst case (pod crash), leader election can take up to 163s (LeaseDuration: 137s + RetryPeriod: 26s).
+	pollDuration = 3 * time.Minute
+	pollInterval = time.Second
+)
+
+func TestClusterCatalogUnpacking(t *testing.T) {
+	ctx := context.Background()
+
+	t.Log("Checking that the controller-manager deployment is updated")
+	managerLabelSelector := labels.Set{"app.kubernetes.io/name": "catalogd"}
+	var managerDeployment appsv1.Deployment
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var managerDeployments appsv1.DeploymentList
+		err := c.List(ctx, &managerDeployments, client.MatchingLabels(managerLabelSelector), client.InNamespace("olmv1-system"))
+		require.NoError(ct, err)
+		require.Len(ct, managerDeployments.Items, 1)
+		managerDeployment = managerDeployments.Items[0]
+		require.Equal(ct, *managerDeployment.Spec.Replicas, managerDeployment.Status.UpdatedReplicas)
+		require.Equal(ct, *managerDeployment.Spec.Replicas, managerDeployment.Status.Replicas)
+		require.Equal(ct, *managerDeployment.Spec.Replicas, managerDeployment.Status.AvailableReplicas)
+		require.Equal(ct, *managerDeployment.Spec.Replicas, managerDeployment.Status.ReadyReplicas)
+	}, pollDuration, pollInterval)
+
+	t.Log("Waiting for controller-manager pods to match the desired replica count")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var managerPods corev1.PodList
+		err := c.List(ctx, &managerPods, client.MatchingLabels(managerLabelSelector), client.InNamespace("olmv1-system"))
+		require.NoError(ct, err)
+		require.Len(ct, managerPods.Items, int(*managerDeployment.Spec.Replicas))
+	}, pollDuration, pollInterval)
+
+	t.Log("Waiting for acquired leader election")
+	leaderCtx, leaderCancel := context.WithTimeout(ctx, pollDuration)
+	defer leaderCancel()
+
+	// When there are multiple replicas, find the leader pod
+	managerPod, err := findLeaderPod(leaderCtx, "catalogd")
+	require.NoError(t, err)
+	require.NotNil(t, managerPod)
+
+	t.Log("Reading logs to make sure that ClusterCatalog was reconciled by catalogdv1")
+	logCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	substrings := []string{
+		"reconcile ending",
+		fmt.Sprintf(`ClusterCatalog=%q`, testClusterCatalogName),
+	}
+	found, err := watchPodLogsForSubstring(logCtx, managerPod, substrings...)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	catalog := &ocv1.ClusterCatalog{}
+	t.Log("Ensuring ClusterCatalog has Status.Condition of Progressing with a status == True, reason == Succeeded")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, types.NamespacedName{Name: testClusterCatalogName}, catalog)
+		require.NoError(ct, err)
+		cond := apimeta.FindStatusCondition(catalog.Status.Conditions, ocv1.TypeProgressing)
+		require.NotNil(ct, cond)
+		require.Equal(ct, metav1.ConditionTrue, cond.Status)
+		require.Equal(ct, ocv1.ReasonSucceeded, cond.Reason)
+	}, pollDuration, pollInterval)
+
+	t.Log("Ensuring ClusterCatalog has Status.Condition of Serving with a status == True, reason == Available")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := c.Get(ctx, types.NamespacedName{Name: testClusterCatalogName}, catalog)
+		require.NoError(ct, err)
+		cond := apimeta.FindStatusCondition(catalog.Status.Conditions, ocv1.TypeServing)
+		require.NotNil(ct, cond)
+		require.Equal(ct, metav1.ConditionTrue, cond.Status)
+		require.Equal(ct, ocv1.ReasonAvailable, cond.Reason)
+	}, pollDuration, pollInterval)
+}
+
+func TestClusterExtensionAfterOLMUpgrade(t *testing.T) {
+	t.Log("Starting checks after OLM upgrade")
+	ctx := context.Background()
+	defer testutil.CollectTestArtifacts(t, artifactName, c, cfg)
+
+	// wait for catalogd deployment to finish
+	t.Log("Wait for catalogd deployment to be ready")
+	waitForDeployment(t, ctx, "catalogd")
+
+	// Find the catalogd leader pod
+	catalogdLeaderCtx, catalogdLeaderCancel := context.WithTimeout(ctx, pollDuration)
+	defer catalogdLeaderCancel()
+	catalogdManagerPod, err := findLeaderPod(catalogdLeaderCtx, "catalogd")
+	require.NoError(t, err)
+	require.NotNil(t, catalogdManagerPod)
+
+	// wait for operator-controller deployment to finish
+	t.Log("Wait for operator-controller deployment to be ready")
+	waitForDeployment(t, ctx, "operator-controller")
+
+	t.Log("Wait for acquired leader election")
+	// Average case is under 1 minute but in the worst case: (previous leader crashed)
+	// we could have LeaseDuration (137s) + RetryPeriod (26s) +/- 163s
+	leaderCtx, leaderCancel := context.WithTimeout(ctx, pollDuration)
+	defer leaderCancel()
+
+	// When there are multiple replicas, find the leader pod
+	var managerPod *corev1.Pod
+	managerPod, err = findLeaderPod(leaderCtx, "operator-controller")
+	require.NoError(t, err)
+	require.NotNil(t, managerPod)
+
+	t.Log("Reading logs to make sure that ClusterExtension was reconciled by operator-controller before we update it")
+	// Make sure that after we upgrade OLM itself we can still reconcile old objects without any changes
+	logCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	substrings := []string{
+		"reconcile ending",
+		fmt.Sprintf(`ClusterExtension=%q`, testClusterExtensionName),
+	}
+	found, err := watchPodLogsForSubstring(logCtx, managerPod, substrings...)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	t.Log("Checking that the ClusterCatalog is unpacked")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var clusterCatalog ocv1.ClusterCatalog
+		require.NoError(ct, c.Get(ctx, types.NamespacedName{Name: testClusterCatalogName}, &clusterCatalog))
+
+		// check serving condition
+		cond := apimeta.FindStatusCondition(clusterCatalog.Status.Conditions, ocv1.TypeServing)
+		require.NotNil(ct, cond)
+		require.Equal(ct, metav1.ConditionTrue, cond.Status)
+		require.Equal(ct, ocv1.ReasonAvailable, cond.Reason)
+
+		// mitigation for upgrade-e2e flakiness caused by the following bug
+		// https://github.com/operator-framework/operator-controller/issues/1626
+		// wait until the unpack time > than the catalogd controller pod creation time
+		cond = apimeta.FindStatusCondition(clusterCatalog.Status.Conditions, ocv1.TypeProgressing)
+		if cond == nil {
+			return
+		}
+		require.Equal(ct, metav1.ConditionTrue, cond.Status)
+		require.Equal(ct, ocv1.ReasonSucceeded, cond.Reason)
+
+		require.True(ct, clusterCatalog.Status.LastUnpacked.After(catalogdManagerPod.CreationTimestamp.Time))
+	}, pollDuration, pollInterval)
+
+	// TODO: if we change the underlying revision storage mechanism, the new version
+	//   will not detect any installed versions, we need to make sure that the upgrade
+	//   test fails across revision storage mechanism changes that are not also accompanied
+	//   by code that automatically migrates the revision storage.
+
+	t.Log("Checking that the ClusterExtension is installed")
+	var clusterExtension ocv1.ClusterExtension
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.NoError(ct, c.Get(ctx, types.NamespacedName{Name: testClusterExtensionName}, &clusterExtension))
+		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1.TypeInstalled)
+		require.NotNil(ct, cond)
+		require.Equal(ct, metav1.ConditionTrue, cond.Status)
+		require.Equal(ct, ocv1.ReasonSucceeded, cond.Reason)
+		require.Contains(ct, cond.Message, "Installed bundle")
+		require.NotNil(ct, clusterExtension.Status.Install)
+		require.NotEmpty(ct, clusterExtension.Status.Install.Bundle.Version)
+	}, pollDuration, pollInterval)
+
+	previousVersion := clusterExtension.Status.Install.Bundle.Version
+
+	t.Log("Updating the ClusterExtension to change version")
+	// Make sure that after we upgrade OLM itself we can still reconcile old objects if we change them
+	clusterExtension.Spec.Source.Catalog.Version = "1.0.1"
+	require.NoError(t, c.Update(ctx, &clusterExtension))
+
+	t.Log("Checking that the ClusterExtension installs successfully")
+	// Use 10 minutes for post-OLM-upgrade extension upgrade operations.
+	// After upgrading OLM itself, the system needs time to:
+	// - Stabilize after operator-controller pods restart (leader election: up to 163s)
+	// - Process the ClusterExtension spec change
+	// - Resolve and unpack the new bundle (1.0.1)
+	// - Apply manifests and wait for rollout
+	// In multi-replica deployments with recent OLM upgrade, this can take significant time
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.NoError(ct, c.Get(ctx, types.NamespacedName{Name: testClusterExtensionName}, &clusterExtension))
+		cond := apimeta.FindStatusCondition(clusterExtension.Status.Conditions, ocv1.TypeInstalled)
+		require.NotNil(ct, cond)
+		require.Equal(ct, ocv1.ReasonSucceeded, cond.Reason)
+		require.Contains(ct, cond.Message, "Installed bundle")
+		require.Equal(ct, ocv1.BundleMetadata{Name: "test-operator.1.0.1", Version: "1.0.1"}, clusterExtension.Status.Install.Bundle)
+		require.NotEqual(ct, previousVersion, clusterExtension.Status.Install.Bundle.Version)
+	}, 10*time.Minute, pollInterval)
+}
+
+// waitForDeployment checks that the updated deployment with the given app.kubernetes.io/name label
+// has reached the desired number of replicas and that the number pods matches that number
+// i.e. no old pods remain.
+func waitForDeployment(t *testing.T, ctx context.Context, controlPlaneLabel string) {
+	deploymentLabelSelector := labels.Set{"app.kubernetes.io/name": controlPlaneLabel}.AsSelector()
+
+	t.Log("Checking that the deployment is updated and available")
+	var desiredNumReplicas int32
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var managerDeployments appsv1.DeploymentList
+		require.NoError(ct, c.List(ctx, &managerDeployments, client.MatchingLabelsSelector{Selector: deploymentLabelSelector}, client.InNamespace("olmv1-system")))
+		require.Len(ct, managerDeployments.Items, 1)
+		managerDeployment := managerDeployments.Items[0]
+
+		require.True(ct,
+			managerDeployment.Status.UpdatedReplicas == *managerDeployment.Spec.Replicas &&
+				managerDeployment.Status.Replicas == *managerDeployment.Spec.Replicas &&
+				managerDeployment.Status.AvailableReplicas == *managerDeployment.Spec.Replicas &&
+				managerDeployment.Status.ReadyReplicas == *managerDeployment.Spec.Replicas,
+		)
+
+		// Check that the deployment has the Available condition set to True
+		var availableCond *appsv1.DeploymentCondition
+		for i := range managerDeployment.Status.Conditions {
+			if managerDeployment.Status.Conditions[i].Type == appsv1.DeploymentAvailable {
+				availableCond = &managerDeployment.Status.Conditions[i]
+				break
+			}
+		}
+		require.NotNil(ct, availableCond, "Available condition not found")
+		require.Equal(ct, corev1.ConditionTrue, availableCond.Status, "Deployment Available condition is not True")
+
+		desiredNumReplicas = *managerDeployment.Spec.Replicas
+	}, pollDuration, pollInterval)
+
+	t.Logf("Ensure the number of remaining pods equal the desired number of replicas (%d)", desiredNumReplicas)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var managerPods corev1.PodList
+		require.NoError(ct, c.List(ctx, &managerPods, client.MatchingLabelsSelector{Selector: deploymentLabelSelector}, client.InNamespace("olmv1-system")))
+		require.Len(ct, managerPods.Items, int(desiredNumReplicas))
+	}, pollDuration, pollInterval)
+}
+
+// findLeaderPod finds the pod that has acquired the leader lease by inspecting the Lease resource.
+// This is more reliable than checking logs as it directly queries the Kubernetes API for the lease holder.
+func findLeaderPod(ctx context.Context, controlPlaneLabel string) (*corev1.Pod, error) {
+	// Map component name to its LeaderElectionID
+	leaseNameMap := map[string]string{
+		"operator-controller": "9c4404e7.operatorframework.io",
+		"catalogd":            "catalogd-operator-lock",
+	}
+
+	leaseName, ok := leaseNameMap[controlPlaneLabel]
+	if !ok {
+		return nil, fmt.Errorf("unknown control plane label: %s", controlPlaneLabel)
+	}
+
+	var leaderPod *corev1.Pod
+
+	// Use wait.PollUntilContextTimeout for polling with proper context handling
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, pollDuration, true, func(ctx context.Context) (bool, error) {
+		// Fetch lease to get the current leader's identity
+		var lease coordinationv1.Lease
+		if err := c.Get(ctx, types.NamespacedName{
+			Name:      leaseName,
+			Namespace: "olmv1-system",
+		}, &lease); err != nil {
+			// Lease might not exist yet, retry
+			return false, nil
+		}
+
+		if lease.Spec.HolderIdentity == nil {
+			// No leader elected yet, retry
+			return false, nil
+		}
+
+		// The HolderIdentity is in the format "pod-name_hash"
+		// Extract the pod name by splitting on "_"
+		holderIdentity := *lease.Spec.HolderIdentity
+		podName := strings.Split(holderIdentity, "_")[0]
+
+		// Directly fetch the pod by name instead of listing all pods
+		pod := &corev1.Pod{}
+		if err := c.Get(ctx, types.NamespacedName{
+			Name:      podName,
+			Namespace: "olmv1-system",
+		}, pod); err != nil {
+			// Pod might not exist yet or is being terminated, retry
+			return false, nil
+		}
+
+		leaderPod = pod
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("timeout waiting for leader election: %w", err)
+	}
+
+	return leaderPod, nil
+}
+
+func watchPodLogsForSubstring(ctx context.Context, pod *corev1.Pod, substrings ...string) (bool, error) {
+	podLogOpts := corev1.PodLogOptions{
+		Follow:    true,
+		Container: container,
+	}
+
+	req := kclientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer podLogs.Close()
+
+	scanner := bufio.NewScanner(podLogs)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		foundCount := 0
+		for _, substring := range substrings {
+			if strings.Contains(line, substring) {
+				foundCount++
+			}
+		}
+		if foundCount == len(substrings) {
+			return true, nil
+		}
+	}
+
+	return false, scanner.Err()
+}


### PR DESCRIPTION
To address: OLM pdb blocks the MCO drain. 
```
jiazha-mac:~ jiazha$ omg get pdb -A
NAMESPACE                             NAME                                    AGE
...
openshift-operator-controller         operator-controller-controller-manager  2h9m
...
openshift-catalogd                    catalogd-controller-manager             2h9m
```

```
  /namespaces/openshift-machine-config-operator/pods/machine-config-controller-ddcbcf474-f8bhx/machine-config-controller/machine-config-controller/logs/current.log):

  2025-12-02T05:30:48.091087Z node ci-op-lnbvjnkk-7649c-r6jfj-master-0: Drain failed.
  Drain has been failing for more than 10 minutes. Waiting 5 minutes then retrying.
  Error message from drain: [
    error when evicting pods/"catalogd-controller-manager-6bd9bd869b-272v6" -n "openshift-catalogd": global timeout reached: 1m30s,
    error when evicting pods/"operator-controller-controller-manager-86444b95d6-gtxjl" -n "openshift-operator-controller": global timeout reached: 1m30s
  ]
```
More on Slack: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1764766284275389