### PR TITLE
OCPQE-31553:adjust watchnamespace qe case based on change

### DIFF
--- a/openshift/tests-extension/test/qe/specs/olmv1_ce_watchns.go
+++ b/openshift/tests-extension/test/qe/specs/olmv1_ce_watchns.go
@@ -249,9 +249,9 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 		ceNoConfig.Delete(oc)
 		e2e.Logf("Scenario 2-1 cleanup: ClusterExtension deleted")
 
-		g.By("Scenario 2-2: Empty string watchNamespace - expect AllNamespaces mode success")
+		g.By("Scenario 2-2: Empty string watchNamespace - expect minLength validation error")
 		e2e.Logf("Testing ClusterExtension with {All,Own,Single} InstallModes and empty watchNamespace")
-		e2e.Logf("Expected behavior: Empty watchNamespace defaults to AllNamespaces mode")
+		e2e.Logf("Expected behavior: Empty watchNamespace violates minLength constraint and fails validation")
 		ceEmptyString := olmv1util.ClusterExtensionDescription{
 			Name:             "ce-" + caseID + "-empty",
 			PackageName:      "nginx-ok-v85543",
@@ -264,12 +264,13 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 			Template:         clusterextensionConfigTemplate,
 		}
 		defer ceEmptyString.Delete(oc)
-		// For {All,Own,Single} InstallModes, empty string defaults to AllNamespaces mode
-		ceEmptyString.Create(oc)
+		_ = ceEmptyString.CreateWithoutCheck(oc)
+		// Empty string violates minLength: 1 validation
+		ceEmptyString.CheckClusterExtensionCondition(oc, "Progressing", "message", "minimum length of 1", 3, 60, 0)
 		// Print full ClusterExtension resource for manual test documentation
 		e2e.Logf("=== ClusterExtension EmptyString resource ===")
 		_ = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterextension", ceEmptyString.Name, "-o", "yaml").Execute()
-		e2e.Logf("PASS: Scenario 2-2 passed: ClusterExtension with empty watchNamespace installed successfully in AllNamespaces mode")
+		e2e.Logf("PASS: Scenario 2-2 passed: ClusterExtension with empty watchNamespace correctly rejected with minLength validation error")
 		ceEmptyString.Delete(oc)
 		e2e.Logf("Scenario 2-2 cleanup: ClusterExtension deleted")
 
@@ -407,7 +408,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 		ceNoConfig.Delete(oc)
 		e2e.Logf("Scenario 3-1 cleanup: ClusterExtension deleted")
 
-		g.By("Scenario 3-2: Empty string watchNamespace - expect validation error")
+		g.By("Scenario 3-2: Empty string watchNamespace - expect minLength validation error")
 		e2e.Logf("Testing ClusterExtension with {Own,Single} InstallModes and empty watchNamespace")
 		ceEmptyString := olmv1util.ClusterExtensionDescription{
 			Name:             "ce-" + caseID + "-empty",
@@ -422,12 +423,12 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 		}
 		defer ceEmptyString.Delete(oc)
 		_ = ceEmptyString.CreateWithoutCheck(oc)
-		// Empty string is a supported field but invalid value (DNS format validation)
-		ceEmptyString.CheckClusterExtensionCondition(oc, "Progressing", "message", "invalid", 3, 60, 0)
+		// Empty string violates minLength: 1 validation
+		ceEmptyString.CheckClusterExtensionCondition(oc, "Progressing", "message", "minimum length of 1", 3, 60, 0)
 		// Print full ClusterExtension resource for manual test documentation
 		e2e.Logf("=== ClusterExtension EmptyString resource ===")
 		_ = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterextension", ceEmptyString.Name, "-o", "yaml").Execute()
-		e2e.Logf("PASS: Scenario 3-2 passed: ClusterExtension with empty watchNamespace correctly rejected with validation error")
+		e2e.Logf("PASS: Scenario 3-2 passed: ClusterExtension with empty watchNamespace correctly rejected with minLength validation error")
 		ceEmptyString.Delete(oc)
 		e2e.Logf("Scenario 3-2 cleanup: ClusterExtension deleted")
 
@@ -568,7 +569,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 		ceNoConfig.Delete(oc)
 		e2e.Logf("Scenario 5-1 cleanup: ClusterExtension deleted")
 
-		g.By("Scenario 5-2: watchNamespace is empty string - expect DNS validation error")
+		g.By("Scenario 5-2: watchNamespace is empty string - expect minLength validation error")
 		e2e.Logf("Testing ClusterExtension with {Single} InstallMode and watchNamespace=''")
 		ceEmptyString := olmv1util.ClusterExtensionDescription{
 			Name:             "ce-" + caseID + "-empty",
@@ -583,11 +584,12 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 		}
 		defer ceEmptyString.Delete(oc)
 		_ = ceEmptyString.CreateWithoutCheck(oc)
-		ceEmptyString.CheckClusterExtensionCondition(oc, "Progressing", "message", "invalid", 3, 60, 0)
+		// Empty string violates minLength: 1 validation
+		ceEmptyString.CheckClusterExtensionCondition(oc, "Progressing", "message", "minimum length of 1", 3, 60, 0)
 		// Print full ClusterExtension resource for manual test documentation
 		e2e.Logf("=== ClusterExtension EmptyString resource ===")
 		_ = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterextension", ceEmptyString.Name, "-o", "yaml").Execute()
-		e2e.Logf("PASS: Scenario 5-2 passed: Got expected DNS validation error for empty string")
+		e2e.Logf("PASS: Scenario 5-2 passed: Got expected minLength validation error for empty string")
 		ceEmptyString.Delete(oc)
 		e2e.Logf("Scenario 5-2 cleanup: ClusterExtension deleted")
 
@@ -733,9 +735,9 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 		ceNoConfig.Delete(oc)
 		e2e.Logf("Scenario 4-1 cleanup: ClusterExtension deleted")
 
-		g.By("Scenario 4-2: watchNamespace is empty string - expect DNS validation error")
+		g.By("Scenario 4-2: watchNamespace is empty string - expect OwnNamespace mode validation error")
 		e2e.Logf("Testing ClusterExtension with {Own} InstallMode and watchNamespace=''")
-		e2e.Logf("Expected behavior: watchNamespace field should be supported with DNS validation")
+		e2e.Logf("Expected behavior: Empty watchNamespace violates OwnNamespace mode requirement (must equal install namespace)")
 		ceEmptyString := olmv1util.ClusterExtensionDescription{
 			Name:             "ce-" + caseID + "-empty",
 			PackageName:      "nginx-ok-v85549",
@@ -749,12 +751,12 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension watchNamespace config
 		}
 		defer ceEmptyString.Delete(oc)
 		_ = ceEmptyString.CreateWithoutCheck(oc)
-		// Empty string should fail with DNS validation error
-		ceEmptyString.CheckClusterExtensionCondition(oc, "Progressing", "message", "invalid", 3, 60, 0)
+		// For OwnNamespace-only bundles, empty string violates the business logic that watchNamespace must equal install namespace
+		ceEmptyString.CheckClusterExtensionCondition(oc, "Progressing", "message", "is not valid ownNamespaceInstallMode", 3, 60, 0)
 		// Print full ClusterExtension resource for manual test documentation
 		e2e.Logf("=== ClusterExtension EmptyString resource ===")
 		_ = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterextension", ceEmptyString.Name, "-o", "yaml").Execute()
-		e2e.Logf("PASS: Scenario 4-2 passed: ClusterExtension with empty watchNamespace correctly rejected with validation error")
+		e2e.Logf("PASS: Scenario 4-2 passed: ClusterExtension with empty watchNamespace correctly rejected with OwnNamespace mode validation error")
 		ceEmptyString.Delete(oc)
 		e2e.Logf("Scenario 4-2 cleanup: ClusterExtension deleted")
 


### PR DESCRIPTION
/cc @jianzhangbjz @Xia-Zhao-rh @bandrade 

Based on the PR 2468 in https://github.com/openshift/operator-framework-operator-controller/pull/622, we need to adjust the case.

so, it need to be merged after #622 

```console
started: 0/1/6 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85546-watchNamespace configuration with OwnNamespace+SingleNamespace InstallModes"

started: 0/2/6 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85543-watchNamespace configuration with AllNamespaces+OwnNamespace+SingleNamespace InstallModes"

started: 0/3/6 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85549-watchNamespace configuration with OwnNamespace InstallMode"

started: 0/4/6 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85547-watchNamespace configuration with SingleNamespace InstallMode"

started: 0/5/6 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85650-[Skipped:Disconnected]API-level error validation for watchNamespace configuration"

started: 0/6/6 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85510-watchNamespace configuration with AllNamespaces InstallMode"


passed: (2m6s) 2026-02-02T02:41:40 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85650-[Skipped:Disconnected]API-level error validation for watchNamespace configuration"


passed: (3m20s) 2026-02-02T02:42:53 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85510-watchNamespace configuration with AllNamespaces InstallMode"


passed: (3m34s) 2026-02-02T02:43:07 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85543-watchNamespace configuration with AllNamespaces+OwnNamespace+SingleNamespace InstallModes"


passed: (3m36s) 2026-02-02T02:43:10 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85549-watchNamespace configuration with OwnNamespace InstallMode"


passed: (3m52s) 2026-02-02T02:43:25 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85546-watchNamespace configuration with OwnNamespace+SingleNamespace InstallModes"


passed: (4m8s) 2026-02-02T02:43:41 "[sig-olmv1][Jira:OLM] clusterextension watchNamespace configuration PolarionID:85547-watchNamespace configuration with SingleNamespace InstallMode"

Shutting down the monitor
Collecting data.
INFO[0451] Starting CollectData for all monitor tests   
INFO[0451]   Starting CollectData for [Monitor:watch-namespaces][Jira:"Test Framework"] monitor test watch-namespaces collection 
INFO[0451]   Finished CollectData for [Monitor:watch-namespaces][Jira:"Test Framework"] monitor test watch-namespaces collection 
INFO[0451] Finished CollectData for all monitor tests   
Computing intervals.
Evaluating tests.
Cleaning up.
INFO[0451] beginning cleanup                             monitorTest=watch-namespaces
Serializing results.
Writing to storage.
  m.startTime = 2026-02-02 10:39:26.879391 +0800 CST m=+195.989598501
  m.stopTime  = 2026-02-02 10:43:41.943474 +0800 CST m=+451.053626751
Processing monitorTest: watch-namespaces
  finalIntervals size = 12
  first interval time: From = 2026-02-02 10:39:26.883577 +0800 CST m=+195.993784543; To = 2026-02-02 10:39:26.883577 +0800 CST m=+195.993784543
  last interval time: From = 2026-02-02 10:43:41.943271 +0800 CST m=+451.053424376; To = 2026-02-02 10:43:41.943271 +0800 CST m=+451.053424376
Writing junits.
Writing JUnit report to e2e-monitor-tests__20260202-023625.xml
6 pass, 0 flaky, 0 skip (7m17s)
```

Assisted-By: Claude Code