### PR TITLE
OPRUN-4546: Fix boxcutter finalizer ResourceNames in preflight test

### DIFF
--- a/openshift/tests-extension/test/olmv1-preflight.go
+++ b/openshift/tests-extension/test/olmv1-preflight.go
@@ -187,7 +187,7 @@ func createDeficientClusterRole(scenario preflightAuthTestScenario, name, ceName
 				APIGroups:     []string{"olm.operatorframework.io"},
 				Resources:     []string{"clusterobjectsets/finalizers"},
 				Verbs:         []string{"update"},
-				ResourceNames: []string{ceName},
+				ResourceNames: []string{fmt.Sprintf("%s-1", ceName)},
 			},
 		}
 	} else {


### PR DESCRIPTION


**Motivation**: https://github.com/openshift/operator-framework-operator-controller/pull/682#discussion_r3017892351