### PR TITLE
OPRUN-4577: OTE: Simplify by remove option to configure tests to run outside of OCP

### DIFF
--- a/openshift/tests-extension/README.md
+++ b/openshift/tests-extension/README.md
@@ -2,7 +2,7 @@
 ========================
 
 This repository contains the OLMv1 tests for OpenShift.
-These tests run against OpenShift clusters and are meant to be used in the OpenShift CI/CD pipeline.
+These tests are designed to run exclusively on OpenShift clusters and are used in the OpenShift CI/CD pipeline.
 They use the framework: https://github.com/openshift-eng/openshift-tests-extension
 
 ## How it works
@@ -117,8 +117,8 @@ Example ([source](https://github.com/openshift/release/blob/main/ci-operator/con
 
 ## How to Run the Tests Locally
 
-The tests can be run locally using the `olmv1-tests-ext` binary against an OpenShift cluster or a vanilla Kubernetes cluster.
-Features and checks which are OpenShift-specific will be skipped when running against a vanilla Kubernetes cluster.
+The tests can be run locally using the `olmv1-tests-ext` binary against an OpenShift cluster.
+These tests are specifically designed for OpenShift and require OpenShift-specific APIs and features.
 
 Use the environment variable `KUBECONFIG` to point to your cluster configuration file such as:
 
@@ -127,9 +127,9 @@ KUBECONFIG=path/to/kubeconfig ./bin/olmv1-tests-ext run-test -n <test-name>
 ```
 
 To run tests that include tech preview features, 
-you need a cluster with OLMv1 installed and those features enabled.
+you need an OpenShift cluster with OLMv1 installed and those features enabled.
 
-### Local Test using OLMv1 and OCP
+### Local Test using OLMv1 on OpenShift
 
 1. Use the `Cluster Bot` to create an OpenShift cluster with OLMv1 installed.
 
@@ -154,99 +154,6 @@ export KUBECONFIG=~/.kube/cluster-bot.kubeconfig
 ```shell
 ./bin/olmv1-tests-ext run-suite olmv1/all
 ```
-
-### Local Test using OLMv1 and Kind
-
-**Prerequisites:**
-
-Install OLMv1 before running the tests. 
-You can use the `kind` tool to create a local Kubernetes cluster with OLMv1 installed.
-Furthermore, if you are using feature gates in your test you will need to
-ensure that those are enabled in your cluster.
-
-**Example:**
-
-export KUBECONFIG=$HOME/.kube/config
-
-```shell
-$ ./bin/olmv1-tests-ext run-suite olmv1/all
-  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
-  ===============================================================================================================
-  Random Seed: 1753508546 - will randomize all specs
-
-  Will run 1 of 1 specs
-  ------------------------------
-  [sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should verify required CRDs are installed and active
-  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/olmv1.go:37
-  [INFO] [env] Using kubeconfig: /Users/camilam/.kube/config[WARN] Skipping feature capability check: not OpenShift  STEP: verifying CRD clusterextensions.olm.operatorframework.io @ 07/26/25 06:42:26.57
-    STEP: verifying CRD clustercatalogs.olm.operatorframework.io @ 07/26/25 06:42:26.575
-  • [0.026 seconds]
-  ------------------------------
-
-  Ran 1 of 1 Specs in 0.026 seconds
-  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
-  Running Suite:  - /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension
-  ===============================================================================================================
-  Random Seed: 1753508546 - will randomize all specs
-
-  Will run 1 of 1 specs
-  ------------------------------
-  [sig-olmv1] OLMv1 should pass a trivial sanity check
-  /Users/camilam/go/src/github/operator-framework-operator-controller/openshift/tests-extension/test/olmv1.go:26
-  • [0.000 seconds]
-  ------------------------------
-
-  Ran 1 of 1 Specs in 0.000 seconds
-  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
-[
-  {
-    "name": "[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should verify required CRDs are installed and active",
-    "lifecycle": "blocking",
-    "duration": 26,
-    "startTime": "2025-07-26 05:42:26.553886 UTC",
-    "endTime": "2025-07-26 05:42:26.580057 UTC",
-    "result": "passed",
-    "output": "[INFO] [env] Using kubeconfig: /Users/camilam/.kube/config[WARN] Skipping feature capability check: not OpenShift  STEP: verifying CRD clusterextensions.olm.operatorframework.io @ 07/26/25 06:42:26.57\n  STEP: verifying CRD clustercatalogs.olm.operatorframework.io @ 07/26/25 06:42:26.575\n"
-  },
-  {
-    "name": "[sig-olmv1] OLMv1 should pass a trivial sanity check",
-    "lifecycle": "blocking",
-    "duration": 26,
-    "startTime": "2025-07-26 05:42:26.553852 UTC",
-    "endTime": "2025-07-26 05:42:26.580263 UTC",
-    "result": "passed",
-    "output": ""
-  }
-]
-```
-
-## Writing Tests
-
-You can write tests in the `openshift/tests-extension/tests/` directory. 
-Please follow these guidelines:
-
-1. Skip OpenShift-specific logic on vanilla Kubernetes
-
-If your test requires OpenShift-only APIs (e.g., clusterversions.config.openshift.io), 
-guard it using `env.Get().IsOpenShift` to ensure it skips gracefully when running 
-on vanilla Kubernetes clusters:
-
-```go
-    if !env.Get().IsOpenShift {
-        extlogs.Warn("Skipping test: not running on OpenShift")
-        Skip("This test requires OpenShift APIs")
-    }
-```
-
-Or, if used within helper functions:
-```go
-    if !env.Get().IsOpenShift {
-        extlogs.Warn("Skipping feature capability check: not OpenShift")
-        return
-    }
-```
-
-This ensures compatibility when running tests in non-OpenShift environments such as KinD.
 
 ## Development Workflow
 

--- a/openshift/tests-extension/pkg/env/cluster.go
+++ b/openshift/tests-extension/pkg/env/cluster.go
@@ -19,7 +19,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,7 +29,8 @@ import (
 )
 
 // TestEnv holds the test environment state, including the Kubernetes REST config,
-// controller-runtime client, and a flag indicating if the cluster is OpenShift.
+// controller-runtime client, and OpenShift version.
+// These tests are designed to run on OpenShift clusters only.
 type TestEnv struct {
 	// RestCfg stores the Kubernetes REST configuration used by clients
 	RestCfg *rest.Config
@@ -38,10 +38,7 @@ type TestEnv struct {
 	// Controller-runtime client for interacting with the cluster
 	K8sClient crclient.Client
 
-	// True if the cluster is detected as an OpenShift environment
-	IsOpenShift bool
-
-	// Set to the MAJOR.MINOR version of OpenShift, blank otherwise
+	// Set to the MAJOR.MINOR version of OpenShift
 	OpenShiftVersion string
 }
 
@@ -79,8 +76,6 @@ func Init() *TestEnv {
 //		})
 func initTestEnv() *TestEnv {
 	cfg := getRestConfig()
-	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(cfg)
-	isOcp := detectOpenShift(discoveryClient)
 
 	// Create the runtime scheme and register all necessary types
 	scheme := runtime.NewScheme()
@@ -91,29 +86,28 @@ func initTestEnv() *TestEnv {
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(olmv1.AddToScheme(scheme))
-
-	if isOcp {
-		utilruntime.Must(buildv1.AddToScheme(scheme))
-		utilruntime.Must(configv1.AddToScheme(scheme))
-		utilruntime.Must(imagev1.AddToScheme(scheme))
-		utilruntime.Must(operatorv1.AddToScheme(scheme))
-	}
+	utilruntime.Must(buildv1.AddToScheme(scheme))
+	utilruntime.Must(configv1.AddToScheme(scheme))
+	utilruntime.Must(imagev1.AddToScheme(scheme))
+	utilruntime.Must(operatorv1.AddToScheme(scheme))
 
 	k8sClient, err := crclient.New(cfg, crclient.Options{Scheme: scheme})
 	if err != nil {
 		log.Fatalf("failed to create controller-runtime client: %v", err)
 	}
 
-	version := ""
-	if isOcp {
-		extlogs.Infof("[env] Cluster environment initialized (OpenShift: %t)\n", isOcp)
-		version = getOcpVersion(k8sClient)
+	version := getOcpVersion(k8sClient)
+	if version != "" {
+		extlogs.Infof("[env] Detected OpenShift version: %s\n", version)
+	} else {
+		extlogs.Warn("[env] Could not detect OpenShift version")
 	}
+
+	extlogs.Infof("[env] Cluster environment initialized successfully\n")
 
 	return &TestEnv{
 		RestCfg:          cfg,
 		K8sClient:        k8sClient,
-		IsOpenShift:      isOcp,
 		OpenShiftVersion: version,
 	}
 }
@@ -122,10 +116,12 @@ func getOcpVersion(c crclient.Client) string {
 	cv := &configv1.ClusterVersion{}
 	err := c.Get(context.Background(), crclient.ObjectKey{Name: "version"}, cv)
 	if err != nil {
+		extlogs.WarnContextf("failed to get ClusterVersion resource: %v", err)
 		return ""
 	}
 	v, err := bsemver.Parse(cv.Status.Desired.Version)
 	if err != nil {
+		extlogs.WarnContextf("failed to parse OpenShift version '%s': %v", cv.Status.Desired.Version, err)
 		return ""
 	}
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
@@ -151,23 +147,6 @@ func getRestConfig() *rest.Config {
 		log.Fatalf("Failed to load in-cluster config: %v", err)
 	}
 	return configureQPS(cfg)
-}
-
-// detectOpenShift checks if the cluster is an OpenShift cluster.
-// It does this by looking for the "config.openshift.io" API group,
-// which only exists in OpenShift environments.
-func detectOpenShift(d discovery.DiscoveryInterface) bool {
-	groups, err := d.ServerGroups()
-	if err != nil {
-		extlogs.WarnContextf("failed to list API groups: %v", err)
-		return false
-	}
-	for _, g := range groups.Groups {
-		if g.Name == "config.openshift.io" {
-			return true
-		}
-	}
-	return false
 }
 
 // configureQPS sets high QPS and burst values to avoid client-side throttling during tests.

--- a/openshift/tests-extension/pkg/helpers/feature_capability.go
+++ b/openshift/tests-extension/pkg/helpers/feature_capability.go
@@ -14,16 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/operator-framework-operator-controller/openshift/tests-extension/pkg/env"
-	"github.com/openshift/operator-framework-operator-controller/openshift/tests-extension/pkg/extlogs"
 )
 
 // RequireOLMv1CapabilityOnOpenshift checks if the OpenShift cluster has
 // OLMv1 capability enabled. If not, it skips the test with a message.
 func RequireOLMv1CapabilityOnOpenshift() {
-	if !env.Get().IsOpenShift {
-		extlogs.Warn("Skipping feature capability check: not OpenShift")
-		return
-	}
 	ctx := context.TODO()
 	clientset := configv1Client()
 	cv, err := clientset.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})

--- a/openshift/tests-extension/pkg/helpers/image_registry.go
+++ b/openshift/tests-extension/pkg/helpers/image_registry.go
@@ -18,11 +18,6 @@ import (
 // This is necessary for tests that depend on the internal image registry service at
 // image-registry.openshift-image-registry.svc:5000
 func RequireImageRegistry(ctx context.Context) {
-	if !env.Get().IsOpenShift {
-		extlogs.Warn("Skipping image-registry check: not OpenShift")
-		return
-	}
-
 	clientset, err := kubernetes.NewForConfig(env.Get().RestCfg)
 	if err != nil {
 		extlogs.WarnContextf("Failed to create kubernetes client for image-registry check: %v", err)

--- a/openshift/tests-extension/test/olmv1-boxcutter.go
+++ b/openshift/tests-extension/test/olmv1-boxcutter.go
@@ -27,9 +27,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMBoxCutterRuntime] OLMv1 Boxcu
 	var unique, nsName, ccName, opName string
 
 	BeforeEach(func(ctx SpecContext) {
-		if !env.Get().IsOpenShift {
-			Skip("Requires OpenShift for Boxcutter runtime tests")
-		}
 		helpers.RequireFeatureGateEnabled(features.FeatureGateNewOLMBoxCutterRuntime)
 		helpers.RequireImageRegistry(ctx)
 

--- a/openshift/tests-extension/test/olmv1-catalog.go
+++ b/openshift/tests-extension/test/olmv1-catalog.go
@@ -33,10 +33,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 	})
 
 	It("should be installed", func(ctx SpecContext) {
-		if !env.Get().IsOpenShift {
-			Skip("Skipping test because it requires OpenShift Catalogs")
-		}
-
 		k8sClient := env.Get().K8sClient
 
 		catalogs := []string{
@@ -159,9 +155,6 @@ func verifyCatalogEndpoint(ctx SpecContext, catalog, endpoint, query string) {
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog", func() {
 	BeforeEach(func() {
 		helpers.RequireOLMv1CapabilityOnOpenshift()
-		if !env.Get().IsOpenShift {
-			Skip("This test requires OpenShift Catalogs")
-		}
 	})
 	It("should serve FBC via the /v1/api/all endpoint", func(ctx SpecContext) {
 		verifyCatalogEndpoint(ctx, "openshift-community-operators", "all", "")
@@ -171,9 +164,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog", func() {
 	BeforeEach(func() {
 		helpers.RequireOLMv1CapabilityOnOpenshift()
-		if !env.Get().IsOpenShift {
-			Skip("This test requires OpenShift Catalogs")
-		}
 	})
 	It("should serve FBC via the /v1/api/all endpoint", func(ctx SpecContext) {
 		verifyCatalogEndpoint(ctx, "openshift-certified-operators", "all", "")
@@ -183,9 +173,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog", func() {
 	BeforeEach(func() {
 		helpers.RequireOLMv1CapabilityOnOpenshift()
-		if !env.Get().IsOpenShift {
-			Skip("This test requires OpenShift Catalogs")
-		}
 	})
 	It("should serve FBC via the /v1/api/all endpoint", func(ctx SpecContext) {
 		verifyCatalogEndpoint(ctx, "openshift-redhat-operators", "all", "")
@@ -195,9 +182,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog", func() {
 	BeforeEach(func() {
 		helpers.RequireOLMv1CapabilityOnOpenshift()
-		if !env.Get().IsOpenShift {
-			Skip("This test requires OpenShift Catalogs")
-		}
 	})
 	It("should serve FBC via the /v1/api/metas endpoint", func(ctx SpecContext) {
 		verifyCatalogEndpoint(ctx, "openshift-community-operators", "metas", "?schema=olm.package")
@@ -207,9 +191,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:D
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog", func() {
 	BeforeEach(func() {
 		helpers.RequireOLMv1CapabilityOnOpenshift()
-		if !env.Get().IsOpenShift {
-			Skip("This test requires OpenShift Catalogs")
-		}
 	})
 	It("should serve FBC via the /v1/api/metas endpoint", func(ctx SpecContext) {
 		verifyCatalogEndpoint(ctx, "openshift-certified-operators", "metas", "?schema=olm.package")
@@ -219,9 +200,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:D
 var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog", func() {
 	BeforeEach(func() {
 		helpers.RequireOLMv1CapabilityOnOpenshift()
-		if !env.Get().IsOpenShift {
-			Skip("This test requires OpenShift Catalogs")
-		}
 	})
 	It("should serve FBC via the /v1/api/metas endpoint", func(ctx SpecContext) {
 		verifyCatalogEndpoint(ctx, "openshift-redhat-operators", "metas", "?schema=olm.package")

--- a/openshift/tests-extension/test/olmv1-deploymentconfig.go
+++ b/openshift/tests-extension/test/olmv1-deploymentconfig.go
@@ -41,9 +41,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMConfigAPI][Skipped:Disconnect
 
 	BeforeAll(func(ctx SpecContext) {
 		By("checking prerequisites")
-		if !env.Get().IsOpenShift {
-			Skip("Requires OpenShift for the tests")
-		}
 		helpers.RequireOLMv1CapabilityOnOpenshift()
 		helpers.RequireImageRegistry(ctx)
 		k8sClient = env.Get().K8sClient

--- a/openshift/tests-extension/test/olmv1-incompatible.go
+++ b/openshift/tests-extension/test/olmv1-incompatible.go
@@ -47,10 +47,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation
 	})
 	It("should block cluster upgrades if an incompatible operator is installed",
 		Label("original-name:[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed"), func(ctx SpecContext) {
-			if !env.Get().IsOpenShift {
-				Skip("Requires OCP APIs: not OpenShift")
-			}
-
 			By("waiting for InstalledOLMOperatorUpgradable to be true")
 			waitForOlmUpgradeStatus(ctx, operatorv1.ConditionTrue, "")
 

--- a/openshift/tests-extension/test/olmv1-singleownnamespace.go
+++ b/openshift/tests-extension/test/olmv1-singleownnamespace.go
@@ -41,10 +41,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 ope
 
 	var unique, saName, crbName, ceName string
 	BeforeEach(func(ctx SpecContext) {
-		By("checking if OpenShift is available for tests")
-		if !env.Get().IsOpenShift {
-			Skip("Requires OpenShift for the tests")
-		}
 		helpers.RequireOLMv1CapabilityOnOpenshift()
 		helpers.RequireImageRegistry(ctx)
 		k8sClient = env.Get().K8sClient
@@ -164,10 +160,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 ope
 
 	var unique, saName, crbName, ceName string
 	BeforeEach(func(ctx SpecContext) {
-		By("checking if OpenShift is available for tests")
-		if !env.Get().IsOpenShift {
-			Skip("Requires OpenShift for the tests")
-		}
 		helpers.RequireOLMv1CapabilityOnOpenshift()
 		helpers.RequireImageRegistry(ctx)
 		k8sClient = env.Get().K8sClient
@@ -282,10 +274,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 ope
 	)
 
 	BeforeEach(func(ctx SpecContext) {
-		By("checking if OpenShift is available for tests")
-		if !env.Get().IsOpenShift {
-			Skip("Requires OpenShift for the tests")
-		}
 		helpers.RequireOLMv1CapabilityOnOpenshift()
 		helpers.RequireImageRegistry(ctx)
 		k8sClient = env.Get().K8sClient
@@ -499,10 +487,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace][Serial] O
 
 	var unique, saName, crbName, ceName string
 	BeforeEach(func(ctx SpecContext) {
-		By("checking if OpenShift is available for tests")
-		if !env.Get().IsOpenShift {
-			Skip("Requires OpenShift for the tests")
-		}
 		helpers.RequireOLMv1CapabilityOnOpenshift()
 		helpers.RequireImageRegistry(ctx)
 		k8sClient = env.Get().K8sClient
@@ -630,10 +614,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLMOwnSingleNamespace] OLMv1 ope
 
 	var unique, saName, crbName, ceName string
 	BeforeEach(func(ctx SpecContext) {
-		By("checking if OpenShift is available for tests")
-		if !env.Get().IsOpenShift {
-			Skip("Requires OpenShift for the tests")
-		}
 		helpers.RequireOLMv1CapabilityOnOpenshift()
 		helpers.RequireImageRegistry(ctx)
 		k8sClient = env.Get().K8sClient

--- a/openshift/tests-extension/test/olmv1.go
+++ b/openshift/tests-extension/test/olmv1.go
@@ -107,10 +107,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1
 	})
 
 	It("should install an openshift catalog cluster extension", Label("original-name:[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should install an openshift catalog cluster extension"), func(ctx SpecContext) {
-		if !env.Get().IsOpenShift {
-			Skip("Requires OCP Catalogs: not OpenShift")
-		}
-
 		By("ensuring no ClusterExtension and CRD for quay-operator")
 		helpers.EnsureCleanupClusterExtension(context.Background(), "quay-operator", "quayregistries.quay.redhat.com")
 
@@ -152,10 +148,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation
 
 	It("should install a cluster extension",
 		Label("original-name:[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should install a cluster extension"), func(ctx SpecContext) {
-			if !env.Get().IsOpenShift {
-				Skip("Requires OCP Catalogs: not OpenShift")
-			}
-
 			By("ensuring no ClusterExtension and CRD for the operator")
 			helpers.EnsureCleanupClusterExtension(context.Background(), opName, "")
 
@@ -169,10 +161,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation
 
 	It("should fail to install a non-existing cluster extension",
 		Label("original-name:[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should fail to install a non-existing cluster extension"), func(ctx SpecContext) {
-			if !env.Get().IsOpenShift {
-				Skip("Requires OCP APIs: not OpenShift")
-			}
-
 			By("ensuring no ClusterExtension and CRD for non-existing operator")
 			helpers.EnsureCleanupClusterExtension(context.Background(), "does-not-exist", "") // No CRD expected for non-existing operator
 


### PR DESCRIPTION
Initially, we considered designing OTE tests in a way that would allow them to run outside of OpenShift. However, almost all implemented tests are configured with IsOpenShift (just preflight and webhooks that are not), and the solution has only been validated against OCP. Therefore, this flexibility is no longer necessary. It seems that the costs of having it are not bringing any value. To keep things simple (KISS principle) and reduce unnecessary complexity, we should remove this option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now run only against OpenShift environments; OpenShift-specific capability and registry checks are enforced for all relevant test suites and specs.
  * Removed prior conditional skips—tests consistently perform OpenShift gating and proceed or skip based on detected OpenShift capabilities.

* **Documentation**
  * Local-run docs updated to require OpenShift; guidance for running on vanilla Kubernetes/Kind and related sections removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->