### PR TITLE
OCPBUGS-62517: Set replicas=1, PDB, and pod anti-affinity for HA topology

### DIFF
--- a/openshift/catalogd/manifests-experimental.yaml
+++ b/openshift/catalogd/manifests-experimental.yaml
@@ -957,6 +957,14 @@ spec:
                     operator: In
                     values:
                       - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    control-plane: catalogd-controller-manager
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/control-plane: ""

--- a/openshift/catalogd/manifests.yaml
+++ b/openshift/catalogd/manifests.yaml
@@ -956,6 +956,14 @@ spec:
                     operator: In
                     values:
                       - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    control-plane: catalogd-controller-manager
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/control-plane: ""

--- a/openshift/helm/catalogd.yaml
+++ b/openshift/helm/catalogd.yaml
@@ -8,6 +8,7 @@ options:
     enabled: true
     deployment:
       image: ${CATALOGD_IMAGE}
+      replicas: 1
     podDisruptionBudget:
       enabled: false
   operatorController:
@@ -25,6 +26,15 @@ namespaces:
 # Deployment values for catalogd
 deployments:
   templateSpec:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  control-plane: catalogd-controller-manager
     priorityClassName: system-cluster-critical
     securityContext:
       seLinuxOptions:

--- a/openshift/helm/operator-controller.yaml
+++ b/openshift/helm/operator-controller.yaml
@@ -8,6 +8,7 @@ options:
     enabled: true
     deployment:
       image: ${OPERATOR_CONTROLLER_IMAGE}
+      replicas: 1
     podDisruptionBudget:
       enabled: false
   catalogd:
@@ -26,6 +27,15 @@ namespaces:
 # Deployment values for operator-controller
 deployments:
   templateSpec:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  control-plane: operator-controller-controller-manager
     priorityClassName: system-cluster-critical
     securityContext:
       seLinuxOptions:

--- a/openshift/operator-controller/manifests-experimental.yaml
+++ b/openshift/operator-controller/manifests-experimental.yaml
@@ -1345,6 +1345,14 @@ spec:
                     operator: In
                     values:
                       - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    control-plane: operator-controller-controller-manager
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/control-plane: ""

--- a/openshift/operator-controller/manifests.yaml
+++ b/openshift/operator-controller/manifests.yaml
@@ -1188,6 +1188,14 @@ spec:
                     operator: In
                     values:
                       - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    control-plane: operator-controller-controller-manager
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/control-plane: ""


### PR DESCRIPTION
Rolling updates in HighlyAvailable clusters leave catalogd and operator-controller unavailable when the only running pod is evicted before its replacement is ready.

Fix by defaulting replicas=1 and PDB disabled in the static Helm values (safe for SNO/External topologies, passes the SNO conformance test that asserts exactly one replica in SingleReplica topology mode). Add pod anti-affinity to prefer scheduling replicas on different nodes.

cluster-olm-operator detects the cluster's ControlPlaneTopology at startup and overrides these values to replicas=2 and PDB enabled when a HighlyAvailable topology is detected, then re-renders the manifests before starting controllers. When a topology change is observed at runtime (exceedingly rare), the operator exits so its deployment
controller restarts it, triggering a fresh Helm render with the correct values for the new topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced preferred pod anti-affinity to bias controller-manager pods to different nodes for improved fault tolerance.
  * Set explicit replica counts in Helm values for catalog and operator controller deployments.
  * Removed outdated notes about replica increases and Pod Disruption Budget additions; no PDBs were added in these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->