### PR TITLE
NO-ISSUE: UPSTREAM: <carry>: remove dead e2e registry push job and related variables

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -34,25 +34,19 @@ verify-manifests: manifests
 E2E_REGISTRY_NAME=docker-registry
 E2E_REGISTRY_NAMESPACE=operator-controller-e2e
 export CLUSTER_REGISTRY_HOST := $(E2E_REGISTRY_NAME).$(E2E_REGISTRY_NAMESPACE).svc:5000
-export REG_PKG_NAME := registry-operator
-export E2E_TEST_CATALOG_V1 := e2e/test-catalog:v1
-export E2E_TEST_CATALOG_V2 := e2e/test-catalog:v2
-export CATALOG_IMG := $(CLUSTER_REGISTRY_HOST)/$(E2E_TEST_CATALOG_V1)
 
-# Order matters here, the ".../registries.conf" entry must be last.
 export DOWNSTREAM_E2E_FLAGS := -count=1 -v
 export DOWNSTREAM_GODOG_FLAGS := ~@mirrored-registry && ~@TLSProfile
 .PHONY: test-e2e
 test-e2e: ## Run the e2e tests.
-	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_IMAGE)
+	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME)
 	cd $(DIR)/../; \
-	LOCAL_REGISTRY_HOST=$$(oc get route $(E2E_REGISTRY_NAME) -n $(E2E_REGISTRY_NAMESPACE) -o jsonpath='{.spec.host}') \
 	go test $(DOWNSTREAM_E2E_FLAGS) ./test/e2e/features_test.go --godog.tags="$(DOWNSTREAM_GODOG_FLAGS)" --k8s.cli=oc
 
 export DOWNSTREAM_EXPERIMENTAL_E2E_FLAGS := -count=1 -v
 .PHONY: test-experimental-e2e
 test-experimental-e2e: ## Run the experimental e2e tests.
-	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME) $(E2E_REGISTRY_IMAGE)
+	$(DIR)/operator-controller/build-test-registry.sh $(E2E_REGISTRY_NAMESPACE) $(E2E_REGISTRY_NAME)
 	cd $(DIR)/../; \
 	go test $(DOWNSTREAM_EXPERIMENTAL_E2E_FLAGS) ./test/experimental-e2e/...;
 

--- a/openshift/operator-controller/build-test-registry.sh
+++ b/openshift/operator-controller/build-test-registry.sh
@@ -7,15 +7,14 @@ set -o pipefail
 help="
 build-test-registry.sh is a script to stand up an image registry within a cluster.
 Usage:
-  build-test-registry.sh [NAMESPACE] [NAME] [IMAGE]
+  build-test-registry.sh [NAMESPACE] [NAME]
 
 Argument Descriptions:
   - NAMESPACE is the namespace that should be created and is the namespace in which the image registry will be created
   - NAME is the name that should be used for the image registry Deployment and Service
-  - IMAGE is the name of the image that should be used to run the image registry
 "
 
-if [[ "$#" -ne 3 ]]; then
+if [[ "$#" -ne 2 ]]; then
   echo "Illegal number of arguments passed"
   echo "${help}"
   exit 1
@@ -23,7 +22,6 @@ fi
 
 namespace=$1
 name=$2
-image=$3
 
 oc apply -f - << EOF
 ---
@@ -85,40 +83,3 @@ spec:
 EOF
 
 oc wait --for=condition=Available -n "${namespace}" "deploy/${name}" --timeout=60s
-
-oc apply -f - << EOF
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ${name}-push
-  namespace: ${namespace}
-spec:
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-      - name: push
-        image: ${image}
-        command:
-        - /push
-        args: 
-        - "--registry-address=${name}.${namespace}.svc:5000"
-        - "--images-path=/images"
-        volumeMounts:
-        - mountPath: /var/certs
-          name: operator-controller-e2e-certs
-        env:
-        - name: SSL_CERT_DIR
-          value: "/var/certs/"
-      volumes:
-        - name: operator-controller-e2e-certs
-          secret:
-            optional: false
-            secretName: operator-controller-e2e-certs
-EOF
-
-oc wait --for=condition=Complete -n "${namespace}" "job/${name}-push" --timeout=60s
-
-oc create route passthrough ${name} --service ${name} -n ${namespace}
-
-oc get route ${name} -n ${namespace} -o yaml


### PR DESCRIPTION
## Summary
- Remove the push Job and route from `openshift/operator-controller/build-test-registry.sh` (upstream's `testdata/push/push.go` is now a no-op stub)
- Drop `E2E_REGISTRY_IMAGE` argument from `build-test-registry.sh` invocations in `openshift/Makefile`
- Remove unused Makefile variables: `REG_PKG_NAME`, `E2E_TEST_CATALOG_V1`, `E2E_TEST_CATALOG_V2`, `CATALOG_IMG`, `LOCAL_REGISTRY_HOST`

## Test plan
- [ ] Verify e2e tests pass in CI without the removed variables and push job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified OpenShift e2e test setup by removing several exported registry/configuration variables.
  * Streamlined test-registry tooling: CLI now requires only namespace and name; the image positional argument is removed.
  * Removed image-push jobs and route creation/printing from the test-registry flow.
  * Updated inline notes to indicate the prior registry image setting remains present but is no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->