### PR TITLE
WIP for test

### DIFF
--- a/openshift/catalogd/manifests-experimental.yaml
+++ b/openshift/catalogd/manifests-experimental.yaml
@@ -1004,7 +1004,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/certified-operator-index:v4.22
+      ref: registry.redhat.io/redhat/certified-operator-index:v5.0
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-community-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1017,7 +1017,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/community-operator-index:v4.22
+      ref: registry.redhat.io/redhat/community-operator-index:v5.0
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1030,7 +1030,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-operator-index:v4.22
+      ref: registry.redhat.io/redhat/redhat-operator-index:v5.0
 ---
 # Source: olmv1/templates/mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
 apiVersion: admissionregistration.k8s.io/v1

--- a/openshift/catalogd/manifests.yaml
+++ b/openshift/catalogd/manifests.yaml
@@ -1003,7 +1003,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/certified-operator-index:v4.22
+      ref: registry.redhat.io/redhat/certified-operator-index:v5.0
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-community-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1016,7 +1016,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/community-operator-index:v4.22
+      ref: registry.redhat.io/redhat/community-operator-index:v5.0
 ---
 # Source: olmv1/templates/openshift-catalogs/clustercatalog-openshift-redhat-operators.yml
 apiVersion: olm.operatorframework.io/v1
@@ -1029,7 +1029,7 @@ spec:
     type: Image
     image:
       pollIntervalMinutes: 10
-      ref: registry.redhat.io/redhat/redhat-operator-index:v4.22
+      ref: registry.redhat.io/redhat/redhat-operator-index:v5.0
 ---
 # Source: olmv1/templates/mutatingwebhookconfiguration-catalogd-mutating-webhook-configuration.yml
 apiVersion: admissionregistration.k8s.io/v1

--- a/openshift/helm/catalogd.yaml
+++ b/openshift/helm/catalogd.yaml
@@ -16,7 +16,7 @@ options:
   openshift:
     enabled: true
     catalogs:
-      version: v4.22
+      version: v5.0
 
 # The set of namespaces
 namespaces:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated catalog image references from v4.22 to v5.0 for certified-operators, community-operators, and redhat-operators across configuration manifests.
  * Configuration otherwise unchanged (poll intervals and other settings remain the same); no public APIs or exported interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->