### PR TITLE
OPRUN-4607: Remove test-experimenal-e2e

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -51,10 +51,6 @@ test-e2e: ## Run the e2e tests.
 		--godog.tags="$(DOWNSTREAM_GODOG_FLAGS)" \
 		--k8s.cli=oc
 
-.PHONY: test-experimental-e2e
-test-experimental-e2e: ## Run the experimental e2e tests.
-	/bin/true # keep - because it's triggered, but always succeed
-
 PHONY: go-build-local
 go-build-local:
 	$(MAKE) -f Makefile go-build-local


### PR DESCRIPTION
It's no longer bring used.

This can be removed since https://github.com/openshift/release/pull/79473 merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration to streamline end-to-end test execution: removed the experimental e2e target and consolidated its behavior into the primary e2e target, which now runs with additional platform-specific and tagged test options to ensure the intended suites run consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->