### PR TITLE
OPRUN-4637: Update dockerfiles to use golang-1.26-release-4.23 builders

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-4.23

--- a/openshift/catalogd.Dockerfile
+++ b/openshift/catalogd.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 
 ARG SOURCE_GIT_COMMIT
 ENV GIT_COMMIT=${SOURCE_GIT_COMMIT}

--- a/openshift/operator-controller.Dockerfile
+++ b/openshift/operator-controller.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23 AS builder
 
 ARG SOURCE_GIT_COMMIT
 ENV GIT_COMMIT=${SOURCE_GIT_COMMIT}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment to Go 1.26 and OpenShift 4.23 for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->