### PR TITLE
OCPBUGS-94187: enable OLMv1 topology-based deployment scaling e2e test

### DIFF
--- a/openshift/tests-extension/test/olmv1-topology.go
+++ b/openshift/tests-extension/test/olmv1-topology.go
@@ -42,7 +42,6 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 topology-based deploy
 	// SingleReplica (SNO) and External topologies keep the chart default of
 	// replicas=1 with no PDB.
 	It("should configure replicas and PodDisruptionBudgets to match the cluster control plane topology", func(ctx SpecContext) {
-		Skip("TODO OCPBUGS-94187: OLMv1 test extension does not yet support the arguments required to run this test")
 		k8sClient := env.Get().K8sClient
 
 		infra := &configv1.Infrastructure{}


### PR DESCRIPTION
Remove the temporary `Skip()` from the topology-based deployment scaling e2e test, now that both prerequisite PRs have merged to release-4.22:

- #758 — HA Helm defaults (`replicas: 1`, `podDisruptionBudget.enabled: false`), pod anti-affinity
- cluster-olm-operator#215 — HA topology detection; scales to `replicas=2` and enables PDB for HighlyAvailable/HighlyAvailableArbiter/DualReplica topologies

The test now verifies end-to-end that `cluster-olm-operator` correctly configures `operator-controller` and `catalogd` deployments based on the cluster's `ControlPlaneTopology`.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-94187

🤖 Generated with [Claude Code](https://claude.com/claude-code)