### PR TITLE
OCPBUGS-97948: Fix ClusterExtension Progressing condition stuck at True after successful install

### DIFF
--- a/internal/operator-controller/controllers/common_controller.go
+++ b/internal/operator-controller/controllers/common_controller.go
@@ -148,13 +148,14 @@ func setInstallStatus(ext *ocv1.ClusterExtension, installStatus *ocv1.ClusterExt
 func setStatusProgressing(ext *ocv1.ClusterExtension, err error) {
 	progressingCond := metav1.Condition{
 		Type:               ocv1.TypeProgressing,
-		Status:             metav1.ConditionTrue,
+		Status:             metav1.ConditionFalse,
 		Reason:             ocv1.ReasonSucceeded,
 		Message:            "Desired state reached",
 		ObservedGeneration: ext.GetGeneration(),
 	}
 
 	if err != nil {
+		progressingCond.Status = metav1.ConditionTrue
 		progressingCond.Reason = ocv1.ReasonRetrying
 		// Unwrap TerminalError to avoid "terminal error:" prefix in message
 		progressingCond.Message = errorutil.SanitizeNetworkError(errorutil.UnwrapTerminal(err))


### PR DESCRIPTION
Bug: https://redhat.atlassian.net/browse/OCPBUGS-97948

## Summary

- The `setStatusProgressing` function in `common_controller.go` defaults the `Progressing` condition to `Status=True` with `Reason=Succeeded` when no error occurs. Per standard Kubernetes condition conventions, `Progressing=True` means work is still in progress. When the desired state has been reached (no error), `Progressing` should be `False`.
- This causes `oc get clusterextension` to permanently show `PROGRESSING=True` even when the operator is fully installed and running correctly.
- Fix: default to `ConditionFalse` (done progressing) and only set `ConditionTrue` when a non-terminal error triggers a retry.
- Affects: 4.18, 4.19, 4.20, 4.21, 4.22, main (all versions since ClusterExtension v1 API was introduced in 4.18)

### Before fix
```
NAME               INSTALLED BUNDLE                        VERSION               INSTALLED   PROGRESSING   AGE
metallb-operator   metallb-operator.v4.22.0-202607011454   4.22.0-202607011454   True        True          3h
```

### After fix
```
NAME               INSTALLED BUNDLE                        VERSION               INSTALLED   PROGRESSING   AGE
metallb-operator   metallb-operator.v4.22.0-202607011454   4.22.0-202607011454   True        False         3h
```

### Condition detail after fix
```json
{
    "type": "Progressing",
    "status": "False",
    "reason": "Succeeded",
    "message": "Desired state reached"
}
```

## Test plan

- [x] Built patched operator-controller binary and deployed to OCP 4.22.2 cluster
- [x] Installed MetalLB operator via ClusterExtension
- [x] Verified `PROGRESSING=False` after successful install (was `True` before fix)
- [x] Verified `INSTALLED=True` remains correct
- [x] Verified condition transitions: `Progressing=True` during rollout → `Progressing=False` once complete
- [ ] Unit tests pass
- [ ] E2E tests pass