### PR TITLE
NO-ISSUE: Remove HelmChartSupport feature gate from experimental manifests

### DIFF
--- a/openshift/helm/experimental.yaml
+++ b/openshift/helm/experimental.yaml
@@ -14,7 +14,6 @@ options:
       - PreflightPermissions
       disabled:
       - WebhookProviderCertManager
-      - HelmChartSupport
       - BoxcutterRuntime
 # List of enabled experimental features for catalogd
 # Use with {{- if has "FeatureGate" .Value.catalogd.features.enabled }}

--- a/openshift/operator-controller/manifests-experimental.yaml
+++ b/openshift/operator-controller/manifests-experimental.yaml
@@ -1237,7 +1237,6 @@ spec:
             - --feature-gates=SingleOwnNamespaceInstallSupport=true
             - --feature-gates=PreflightPermissions=true
             - --feature-gates=WebhookProviderCertManager=false
-            - --feature-gates=HelmChartSupport=false
             - --feature-gates=BoxcutterRuntime=false
             - --tls-cert=/var/certs/tls.crt
             - --tls-key=/var/certs/tls.key


### PR DESCRIPTION
`HelmChartSupport` was removed upstream in [dbc9b4a](https://github.com/operator-framework/operator-controller/commit/dbc9b4a77b7a2fb7a9f451b4f11c4d7d7d804863) but `openshift/helm/experimental.yaml` still listed it as a disabled feature gate, causing `operator-controller-controller-manager` to crash on startup:

```
invalid argument "HelmChartSupport=false" for "--feature-gates" flag: unrecognized feature gate: HelmChartSupport
```

This made the OLM cluster operator `Degraded`/`Unavailable` and caused cluster installation to fail with exit code 6, as seen in the [synchronize-upstream CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_operator-framework-operator-controller/762/pull-ci-openshift-operator-framework-operator-controller-main-openshift-e2e-aws/2077185668236185600).

**Changes:**
- Remove `HelmChartSupport` from `openshift/helm/experimental.yaml`
- Regenerate `openshift/operator-controller/manifests-experimental.yaml` via `make -C openshift manifests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
  - Enabled preflight permission checks in the experimental operator controller.
  - Enabled support for installations scoped to a single namespace.
  - Disabled Helm chart support and webhook provider certificate management in the experimental configuration.
  - Continued using OpenShift service CA support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->