### PR TITLE
OPRUN-4437: test: add allow-case for operator maxOCPVersion > cluster version

### DIFF
--- a/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
+++ b/openshift/tests-extension/.openshift-tests-extension/openshift_payload_olmv1.json
@@ -1498,6 +1498,16 @@
     "environmentSelector": {}
   },
   {
+    "name": "[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation should not block cluster upgrades if the operator's maxOCPVersion exceeds the current cluster version",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:olmv1",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  },
+  {
     "name": "[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {services} are not specified",
     "labels": {},
     "resources": {

--- a/openshift/tests-extension/test/olmv1-incompatible.go
+++ b/openshift/tests-extension/test/olmv1-incompatible.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	//nolint:staticcheck // ST1001: dot-imports for readability
 	. "github.com/onsi/ginkgo/v2"
@@ -61,6 +62,61 @@ var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation
 			By("waiting for ClusterOperator Upgradeable to be false")
 			waitForClusterOperatorUpgradable(ctx, ceName)
 		})
+})
+
+// nextMinorVersion returns the next OCP minor version after the current cluster version.
+// OCP 4.23 and 5.0 are co-released equivalents whose only upgrade target is 5.1, so
+// a cluster at 4.23 returns "5.1" rather than the naive "4.24".
+func nextMinorVersion() string {
+	v := env.Get().OpenShiftVersion // "MAJOR.MINOR", e.g. "5.0"
+	var major, minor int
+	if _, err := fmt.Sscanf(v, "%d.%d", &major, &minor); err != nil {
+		Fail(fmt.Sprintf("failed to parse OpenShift version %q: %v", v, err))
+	}
+	if major == 4 && minor == 23 {
+		return "5.1"
+	}
+	return fmt.Sprintf("%d.%d", major, minor+1)
+}
+
+var _ = Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 operator installation", func() {
+	var unique, nsName, ccName, opName string
+	BeforeEach(func(ctx SpecContext) {
+		replacements := map[string]string{
+			"{{ TEST-BUNDLE }}": "", // Auto-filled
+			"{{ NAMESPACE }}":   "", // Auto-filled
+			"{{ VERSION }}":     nextMinorVersion(),
+
+			// Using the shell image provided by origin as the controller image.
+			// The image is mirrored into disconnected environments for testing.
+			"{{ TEST-CONTROLLER }}": image.ShellImage(),
+		}
+		unique, nsName, ccName, opName = helpers.NewCatalogAndClusterBundles(ctx, replacements,
+			catalogdata.AssetNames, catalogdata.Asset,
+			operatordata.AssetNames, operatordata.Asset,
+		)
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		if CurrentSpecReport().Failed() {
+			By("dumping for debugging")
+			helpers.DescribeAllClusterCatalogs(context.Background())
+			helpers.DescribeAllClusterExtensions(context.Background(), nsName)
+		}
+	})
+
+	It("should not block cluster upgrades if the operator's maxOCPVersion exceeds the current cluster version", func(ctx SpecContext) {
+		By("waiting for InstalledOLMOperatorUpgradable to be true")
+		waitForOlmUpgradeStatus(ctx, operatorv1.ConditionTrue, "")
+
+		By("creating the ClusterExtension")
+		ceName, ceCleanup := helpers.CreateClusterExtension(opName, "", nsName, unique, helpers.WithCatalogNameSelector(ccName))
+		DeferCleanup(ceCleanup)
+		helpers.ExpectClusterExtensionToBeInstalled(ctx, ceName)
+
+		By("verifying InstalledOLMOperatorUpgradable remains true after installing the operator")
+		waitForOlmUpgradeStatus(ctx, operatorv1.ConditionTrue, "")
+	})
 })
 
 func waitForOlmUpgradeStatus(ctx SpecContext, status operatorv1.ConditionStatus, name string) {


### PR DESCRIPTION
Add a second ReleaseGate-eligible OTE test verifying that an operator whose olm.maxOpenShiftVersion exceeds the current cluster version does not block cluster upgrade (InstalledOLMOperatorsUpgradeable stays True).

The existing test only covered the blocking path (maxOCPVersion == current version → False). This covers the complementary allow path (maxOCPVersion == next minor → True), directly exercising the normalization logic introduced for the 4.23/5.0 co-release boundary.

A nextMinorVersion() helper mirrors the 4.23→5.1 special case so the bundle annotation is always set to the correct next upgrade target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended OLMv1 operator installation coverage to run against the next minor OpenShift version.
  * Added a scenario for the NewOLM feature gate to confirm operator installation does not block cluster upgrades when an operator’s maximum supported OpenShift version is higher than the current cluster version.
  * Continued to verify operators install successfully and remain upgradeable after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->