### PR TITLE
OPRUN-4436: fix(test): update PolarionID:87224 for 4.23/5.0 upgrade boundary

### DIFF
--- a/openshift/tests-extension/test/qe/specs/olmv1_ce.go
+++ b/openshift/tests-extension/test/qe/specs/olmv1_ce.go
@@ -1056,7 +1056,7 @@ var _ = g.Describe("[sig-olmv1][Jira:OLM] clusterextension", g.Label("NonHyperSh
 		g.By("check if Upgradeable status is false")
 		errWait := wait.PollUntilContextTimeout(context.TODO(), 3*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 			message, _ := olmv1util.GetNoEmpty(oc, "co", "olm", "-o", `jsonpath={.status.conditions[?(@.type=="Upgradeable")].message}`)
-			if strings.Contains(message, expectedPattern) && strings.Contains(message, "5") {
+			if strings.Contains(message, expectedPattern) {
 				e2e.Logf("message:%s", message)
 				return true, nil
 			}

--- a/openshift/tests-extension/test/qe/util/tools.go
+++ b/openshift/tests-extension/test/qe/util/tools.go
@@ -547,18 +547,21 @@ func PatchResource(oc *CLI, asAdmin bool, withoutNamespace bool, parameters ...s
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
-// GetNextMinorVersion calculates the next minor version string from the current cluster version
+// GetNextMinorVersion calculates the next minor version string from the current cluster version.
 // Parameters:
 //   - oc: CLI client for interacting with the OpenShift cluster
 //
 // Returns:
-//   - string: next minor version in "MAJOR.MINOR" format (e.g., "4.23")
+//   - string: next minor version in "MAJOR.MINOR" format (e.g., "5.1")
 //   - error: error if version retrieval or calculation fails, nil on success
 //
 // Example:
 //
 //	nextVersion, err := GetNextMinorVersion(oc)
-//	// For cluster version "4.22.0-xxx", returns: "4.23", nil
+//	// For cluster version "5.0.0-xxx", returns: "5.1", nil
+//
+// Special case: OCP 4.23 and 5.0 are co-released equivalents; the only upgrade target
+// from either is 5.1. A cluster at 4.23 therefore returns "5.1", not "4.24".
 func GetNextMinorVersion(oc *CLI) (string, error) {
 	if oc == nil {
 		return "", fmt.Errorf("CLI client cannot be nil")
@@ -587,9 +590,10 @@ func GetNextMinorVersion(oc *CLI) (string, error) {
 		return "", fmt.Errorf("failed to parse minor version from %s: %w", parts[1], err)
 	}
 
-	// Calculate next minor version
-	nextMinor := minor + 1
-	nextVersion := fmt.Sprintf("%d.%d", major, nextMinor)
+	// OCP 4.23 and 5.0 are co-released equivalents; the only upgrade target from either is 5.1.
+	if major == 4 && minor == 23 {
+		return "5.1", nil
+	}
 
-	return nextVersion, nil
+	return fmt.Sprintf("%d.%d", major, minor+1), nil
 }


### PR DESCRIPTION
Fix GetNextMinorVersion to return "5.1" for 4.23 clusters instead of "4.24": OCP 4.23 and 5.0 are co-released equivalents whose only upgrade target is 5.1.

Remove the redundant `&& strings.Contains(message, "5")` guard from the Upgradeable message poll — the expectedPattern built from GetNextMinorVersion now encodes the full version string and is sufficient on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgradeability status checks so success is detected based on the expected status content, without requiring an unrelated numeric substring.
  * Added correct next-version calculation for the OpenShift 4.23 co-release case, now returning 5.1 as expected.
  * Kept existing validation and error handling for missing or unparseable version information.
* **Tests**
  * Updated upgradeability polling test expectations to align with the supported upgrade paths and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->