### PR TITLE
NO-ISSUE: Remove stale reviewers/approvers, add trgeiger

### DIFF
--- a/DOWNSTREAM_OWNERS_ALIASES
+++ b/DOWNSTREAM_OWNERS_ALIASES
@@ -1,28 +1,20 @@
-
 aliases:
    # contributors who can approve any PRs in the repo
    operator-framework-approvers:
    - grokspawn
    - joelanford
-   - oceanc80
    - perdasilva
    - tmshort
-   - jianzhangbjz
 
    # contributors who can review/lgtm any PRs in the repo
    operator-framework-reviewers:
-   - anik120
    - ankitathomas
-   - bentito
-   - camilamacedo86
    - dtfranz
    - fgiudici
    - grokspawn
    - joelanford
-   - oceanc80
    - pedjak
    - perdasilva
    - rashmigottipati
-   - thetechnick
    - tmshort
    - trgeiger


### PR DESCRIPTION
Remove stale handles from `DOWNSTREAM_OWNERS_ALIASES`.

**Removed from `operator-framework-approvers`:** `oceanc80`, `jianzhangbjz`
**Removed from `operator-framework-reviewers`:** `anik120`, `bentito`, `camilamacedo86`, `oceanc80`, `rashmigottipati`, `thetechnick`
(`trgeiger` was already present)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated contributor alias lists for approvers and reviewers.
  * Removed outdated entries and adjusted membership for the approvers and reviewers aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->