### PR TITLE
[release-4.21] OCPBUGS-99756: increase catalog HTTP client timeout from 10s to 5m

### DIFF
--- a/internal/shared/util/http/httputil.go
+++ b/internal/shared/util/http/httputil.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BuildHTTPClient(cpw *CertPoolWatcher) (*http.Client, error) {
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient := &http.Client{Timeout: 5 * time.Minute}
 
 	pool, _, err := cpw.Get()
 	if err != nil {


### PR DESCRIPTION
The 10-second timeout was too aggressive for large catalog responses. Increase it to 5 minutes to avoid timeouts when fetching catalogs.