### PR TITLE
OCPBUGS-89330: Fix cache path to avoid /var/cache/dnf conflict

### DIFF
--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -181,7 +181,7 @@ func init() {
 	flags.BoolVar(&cfg.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flags.StringVar(&cfg.cachePath, "cache-path", "/var/cache", "The local directory path used for filesystem based caching")
+	flags.StringVar(&cfg.cachePath, "cache-path", "/var/cache/operator-controller", "The local directory path used for filesystem based caching")
 	flags.StringVar(&cfg.systemNamespace, "system-namespace", "", "Configures the namespace that gets used to deploy system resources.")
 	flags.StringVar(&cfg.globalPullSecret, "global-pull-secret", "", "The <namespace>/<name> of the global pull secret that is going to be used to pull bundle images.")
 


### PR DESCRIPTION
## Problem

On OpenShift 4.19.32, operator-controller pods crash on startup with:
```
chmod /var/cache/dnf: operation not permitted
```

This happens because:
1. Default cache path is `/var/cache`
2. RHEL base image contains `/var/cache/dnf` owned by root
3. Pod runs as non-root (UID 1001)
4. `EnsureEmptyDirectory()` tries to chmod root-owned directories, which fails

## Solution

Change default cache path from `/var/cache` to `/var/cache/operator-controller` to avoid conflicts with system directories.

## Testing

- Build and deploy with new default
- Verify pod starts successfully
- Verify cache operations work correctly

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-89330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default filesystem cache location for the operator-controller by changing the `--cache-path` default from `/var/cache` to `/var/cache/operator-controller`, keeping cache files in a dedicated directory for improved organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->