### PR TITLE
[release-4.20] OCPBUGS-89330: Synchronize From Upstream Repositories

### DIFF
--- a/cmd/catalogd/main.go
+++ b/cmd/catalogd/main.go
@@ -126,7 +126,7 @@ func init() {
 	flags.StringVar(&cfg.systemNamespace, "system-namespace", "", "The namespace catalogd uses for internal state")
 	flags.StringVar(&cfg.catalogServerAddr, "catalogs-server-addr", ":8443", "The address where catalogs' content will be accessible")
 	flags.StringVar(&cfg.externalAddr, "external-address", "catalogd-service.olmv1-system.svc", "External address for http(s) server")
-	flags.StringVar(&cfg.cacheDir, "cache-dir", "/var/cache/", "Directory for file based caching")
+	flags.StringVar(&cfg.cacheDir, "cache-dir", "/var/cache/catalogd", "Directory for file based caching")
 	flags.DurationVar(&cfg.gcInterval, "gc-interval", 12*time.Hour, "Garbage collection interval")
 	flags.StringVar(&cfg.certFile, "tls-cert", "", "Certificate file for TLS")
 	flags.StringVar(&cfg.keyFile, "tls-key", "", "Key file for TLS")

--- a/cmd/operator-controller/main.go
+++ b/cmd/operator-controller/main.go
@@ -145,7 +145,7 @@ func init() {
 	flags.BoolVar(&cfg.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flags.StringVar(&cfg.cachePath, "cache-path", "/var/cache", "The local directory path used for filesystem based caching")
+	flags.StringVar(&cfg.cachePath, "cache-path", "/var/cache/operator-controller", "The local directory path used for filesystem based caching")
 	flags.StringVar(&cfg.systemNamespace, "system-namespace", "", "Configures the namespace that gets used to deploy system resources.")
 	flags.StringVar(&cfg.globalPullSecret, "global-pull-secret", "", "The <namespace>/<name> of the global pull secret that is going to be used to pull bundle images.")
 


### PR DESCRIPTION
Backport of #779 to release-4.20

**Jira**: https://redhat.atlassian.net/browse/OCPBUGS-89330

This fixes CrashLoopBackOff on startup due to `chmod /var/cache/dnf operation not permitted` by using dedicated cache directories instead of conflicting with system paths.