### PR TITLE
OCPBUGS-83515: UPSTREAM: <carry>: use internal shell image for catalog FBC curl Job

### DIFF
--- a/openshift/tests-extension/test/olmv1-catalog.go
+++ b/openshift/tests-extension/test/olmv1-catalog.go
@@ -397,7 +397,7 @@ func buildCurlJob(prefix, namespace, url, serviceAccountName string) *batchv1.Jo
 					RestartPolicy:      corev1.RestartPolicyNever,
 					Containers: []corev1.Container{{
 						Name:    "api-tester",
-						Image:   "registry.redhat.io/rhel8/httpd-24:latest",
+						Image:   image.ShellImage(),
 						Command: []string{"/bin/bash", "-c", commandString},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{


### PR DESCRIPTION
 This PR replaces the hardcoded image `registry.redhat.io/rhel8/httpd-24:latest` (445MB) in `buildCurlJob()` with `image.ShellImage()`, the node-cached `openshift/tools` image. A slow pull could exceed the 5-minute test timeout. All six FBC endpoint specs (`/v1/api/all` and `/v1/api/metas` for the three openshift catalogs) share `buildCurlJob()`, this change fixes all of them. No architectural changes.

Testing
- All six specs pass on OpenShift 4.20.17 with a binary from this branch
- Same Job with old image and new image, giving identical curl results.

Fixes OCPBUGS-83515 (https://issues.redhat.com/browse/OCPBUGS-83515)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the curl verification job to use the configured shell image, improving compatibility with the deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->